### PR TITLE
Don't Install Binaries from Bin Directory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,7 +53,7 @@ executable(
     link_with: [misra_std],
     c_args: common_c_args,
     include_directories: inc_misra,
-    install: true
+    install: false
 )
 
 executable(
@@ -62,7 +62,7 @@ executable(
     link_with: [misra_std],
     c_args: common_c_args,
     include_directories: inc_misra,
-    install: true
+    install: false
 )
 
 executable(
@@ -71,7 +71,7 @@ executable(
     link_with: [misra_std],
     c_args: common_c_args,
     include_directories: inc_misra,
-    install: true
+    install: false
 )
 
 executable(
@@ -80,7 +80,7 @@ executable(
     link_with: [misra_std],
     c_args: common_c_args,
     include_directories: inc_misra,
-    install: true
+    install: false
 )
 
 # Include tests


### PR DESCRIPTION
Binaries in Bin directory are kind-of examples only now. They're not expected to be real programs now (earlier they were intended to be real programs and installed in users binaries install path).

Because I want projects to be separated from this library so it's as minimal as possible, let's just keep Bin as a playground where we can test features during development and provide it as a reference to some working half-assed examples.