### PR TITLE
Automatically Wrap First 256 arguments with `IOFMT` So Users Don't Need To

### DIFF
--- a/Bin/Demangler/Main.c
+++ b/Bin/Demangler/Main.c
@@ -9,10 +9,10 @@ int main(void) {
         VecForeachPtr(&lines, line, {
             if (StrStartsWithZstr(line, "[.") && StrEndsWithZstr(line, "]")) {
                 Str rule_name = StrInit();
-                StrReadFmt(line->data, "[.{}]", FMT(rule_name));
+                StrReadFmt(line->data, "[.{}]", rule_name);
 
                 if (rule_name.length) {
-                    WriteFmtLn("Got Rule : {}", FMT(rule_name));
+                    WriteFmtLn("Got Rule : {}", rule_name);
                     StrDeinit(&rule_name);
                 }
             }

--- a/Bin/ElfInfo.c
+++ b/Bin/ElfInfo.c
@@ -343,15 +343,7 @@ int main(int argc, char** argv) {
     }
 
     ElfHeader64 eh = {0};
-    FReadFmt(
-        elf,
-        FMT_ELF_META,
-        eh.meta.class,
-        eh.meta.encoding,
-        eh.meta.version,
-        eh.meta.os_abi,
-        eh.meta.abi_version
-    );
+    FReadFmt(elf, FMT_ELF_META, eh.meta.class, eh.meta.encoding, eh.meta.version, eh.meta.os_abi, eh.meta.abi_version);
 
     // technically padding here but we can skip it
     fseek(elf, 7, SEEK_CUR);

--- a/Bin/ElfInfo.c
+++ b/Bin/ElfInfo.c
@@ -333,7 +333,7 @@ typedef struct {
 
 int main(int argc, char** argv) {
     if (argc < 2) {
-        LOG_FATAL("USAGE: {} {}", FMT(argv[0]), FMT(argv[1]));
+        LOG_FATAL("USAGE: {} {}", argv[0], argv[1]);
     }
 
     FILE* elf = fopen(argv[1], "rb");
@@ -346,11 +346,11 @@ int main(int argc, char** argv) {
     FReadFmt(
         elf,
         FMT_ELF_META,
-        FMT(eh.meta.class),
-        FMT(eh.meta.encoding),
-        FMT(eh.meta.version),
-        FMT(eh.meta.os_abi),
-        FMT(eh.meta.abi_version)
+        eh.meta.class,
+        eh.meta.encoding,
+        eh.meta.version,
+        eh.meta.os_abi,
+        eh.meta.abi_version
     );
 
     // technically padding here but we can skip it
@@ -360,25 +360,25 @@ int main(int argc, char** argv) {
     // this will also indirectly decide if elf magic is valid
     // for an invalid elf magic, any subsequent fields will be zero, and hence will be invalid
     if (eh.meta.class != ELF_CLASS_64) {
-        LOG_FATAL("Only 64-bit binaries supported for now. Class for provided binary is = {}", FMT(eh.meta.class));
+        LOG_FATAL("Only 64-bit binaries supported for now. Class for provided binary is = {}", eh.meta.class);
     }
 
     FReadFmt(
         elf,
         eh.meta.encoding == ELF_ENCODING_LSB ? FMT_ELF_HEADER_64_LE : FMT_ELF_HEADER_64_BE,
-        FMT(eh.type),
-        FMT(eh.machine),
-        FMT(eh.version),
-        FMT(eh.entry),
-        FMT(eh.program_header_table_offset),
-        FMT(eh.section_header_table_offset),
-        FMT(eh.flags),
-        FMT(eh.elf_header_size),
-        FMT(eh.program_header_entry_size),
-        FMT(eh.program_header_count),
-        FMT(eh.section_header_entry_size),
-        FMT(eh.section_header_count),
-        FMT(eh.string_table_index)
+        eh.type,
+        eh.machine,
+        eh.version,
+        eh.entry,
+        eh.program_header_table_offset,
+        eh.section_header_table_offset,
+        eh.flags,
+        eh.elf_header_size,
+        eh.program_header_entry_size,
+        eh.program_header_count,
+        eh.section_header_entry_size,
+        eh.section_header_count,
+        eh.string_table_index
     );
 
     WriteFmtLn(
@@ -399,24 +399,24 @@ int main(int argc, char** argv) {
         "  string_table_index: {}\n"
         "}}",
 
-        FMT(eh.meta.class),
-        FMT(eh.meta.encoding),
-        FMT(eh.meta.version),
-        FMT(eh.meta.os_abi),
+        eh.meta.class,
+        eh.meta.encoding,
+        eh.meta.version,
+        eh.meta.os_abi,
 
-        FMT(eh.type),
-        FMT(eh.machine),
-        FMT(eh.version),
-        FMT(eh.entry),
-        FMT(eh.program_header_table_offset),
-        FMT(eh.section_header_table_offset),
-        FMT(eh.flags),
-        FMT(eh.elf_header_size),
-        FMT(eh.program_header_entry_size),
-        FMT(eh.program_header_count),
-        FMT(eh.section_header_entry_size),
-        FMT(eh.section_header_count),
-        FMT(eh.string_table_index)
+        eh.type,
+        eh.machine,
+        eh.version,
+        eh.entry,
+        eh.program_header_table_offset,
+        eh.section_header_table_offset,
+        eh.flags,
+        eh.elf_header_size,
+        eh.program_header_entry_size,
+        eh.program_header_count,
+        eh.section_header_entry_size,
+        eh.section_header_count,
+        eh.string_table_index
     );
 
     return 0;

--- a/Bin/MisraDoc.c
+++ b/Bin/MisraDoc.c
@@ -198,13 +198,7 @@ int main(int argc, char** argv) {
                                 "---\n"
                                 "```c\n";
 
-                            StrWriteFmt(
-                                &md_code,
-                                mdHeader,
-                                output_path.data,
-                                output_path.data,
-                                output_path.data
-                            );
+                            StrWriteFmt(&md_code, mdHeader, output_path.data, output_path.data, output_path.data);
                             StrMerge(&md_code, &file_contents);
                             StrWriteFmt(&md_code, "\n```");
 

--- a/Bin/MisraDoc.c
+++ b/Bin/MisraDoc.c
@@ -170,16 +170,16 @@ int main(int argc, char** argv) {
                             &file_contents.length,
                             &file_contents.capacity
                         )) {
-                        LOG_ERROR("Failed to read \"{}\" source file.", FMT(file_path.data));
+                        LOG_ERROR("Failed to read \"{}\" source file.", file_path.data);
                         continue;
                     }
 
                     Str output_path = StrInit();
                     Scope(&output_path, StrDeinit, {
                         StrMerge(&output_path, &file_path);
-                        LOG_INFO("{}", FMT(output_path));
+                        LOG_INFO("{}", output_path);
                         StrReplaceZstr(&output_path, "/", "-", -1);
-                        LOG_INFO("{}", FMT(output_path));
+                        LOG_INFO("{}", output_path);
 
                         Str md_code = StrInit();
                         Scope(&md_code, StrDeinit, {
@@ -201,21 +201,21 @@ int main(int argc, char** argv) {
                             StrWriteFmt(
                                 &md_code,
                                 mdHeader,
-                                FMT(output_path.data),
-                                FMT(output_path.data),
-                                FMT(output_path.data)
+                                output_path.data,
+                                output_path.data,
+                                output_path.data
                             );
                             StrMerge(&md_code, &file_contents);
                             StrWriteFmt(&md_code, "\n```");
 
                             // complete relative file path
                             StrPushFront(&output_path, '/');
-                            LOG_INFO("{}", FMT(output_path));
+                            LOG_INFO("{}", output_path);
                             StrPushFrontCstr(&output_path, project.build_dir.data, project.build_dir.length);
-                            LOG_INFO("{}", FMT(output_path));
+                            LOG_INFO("{}", output_path);
                             StrReplaceZstr(&output_path, ".c", ".md", 1);
                             StrReplaceZstr(&output_path, ".h", ".md", 1);
-                            LOG_INFO("{}\n\n", FMT(output_path));
+                            LOG_INFO("{}\n\n", output_path);
 
 
                             // dump code to output path

--- a/Bin/MisraEnum.c
+++ b/Bin/MisraEnum.c
@@ -147,14 +147,7 @@ int main(int argc, char** argv) {
             invalidEnumName = invalid_enum.name.data;
         }
 
-        StrWriteFmt(
-            &code,
-            funcHeader,
-            enum_name.data,
-            enum_name.data,
-            enum_name.data,
-            invalidEnumName
-        );
+        StrWriteFmt(&code, funcHeader, enum_name.data, enum_name.data, enum_name.data, invalidEnumName);
 
         // Use VecForeach for iterating over entries
         VecForeach(&entries, e, {

--- a/Bin/MisraEnum.c
+++ b/Bin/MisraEnum.c
@@ -93,7 +93,7 @@ int main(int argc, char** argv) {
             }
 
             if (to_from_str && !e.str.length) {
-                LOG_ERROR("to_from_str is set to true but str value not provided for enum {}", FMT(e.name));
+                LOG_ERROR("to_from_str is set to true but str value not provided for enum {}", e.name);
                 abort();
             }
 
@@ -104,25 +104,25 @@ int main(int argc, char** argv) {
     StrClear(&code);
 
     // Use a temporary variable for enum name
-    StrWriteFmt(&code, "typedef enum {} {{\n", FMT(enum_name.data));
+    StrWriteFmt(&code, "typedef enum {} {{\n", enum_name.data);
 
     // last value starts with invalid enum's value
     if (invalid_enum.name.length) {
         last_value = invalid_enum.name.length ? invalid_enum.value : VecFirst(&entries).value;
-        StrWriteFmt(&code, "    {} = {},\n", FMT(invalid_enum.name.data), FMT(invalid_enum.value));
+        StrWriteFmt(&code, "    {} = {},\n", invalid_enum.name.data, invalid_enum.value);
     }
 
     // Use VecForeach for iterating over entries
     VecForeach(&entries, e, {
         if (last_value == e.value - 1) {
-            StrWriteFmt(&code, "    {},\n", FMT(e.name.data));
+            StrWriteFmt(&code, "    {},\n", e.name.data);
         } else {
-            StrWriteFmt(&code, "    {} = {},\n", FMT(e.name.data), FMT(e.value));
+            StrWriteFmt(&code, "    {} = {},\n", e.name.data, e.value);
         }
         last_value = e.value;
     });
 
-    StrWriteFmt(&code, "}} {};\n", FMT(enum_name.data));
+    StrWriteFmt(&code, "}} {};\n", enum_name.data);
 
     if (to_from_str) {
         // Store string literals in temporary variables
@@ -150,10 +150,10 @@ int main(int argc, char** argv) {
         StrWriteFmt(
             &code,
             funcHeader,
-            FMT(enum_name.data),
-            FMT(enum_name.data),
-            FMT(enum_name.data),
-            FMT(invalidEnumName)
+            enum_name.data,
+            enum_name.data,
+            enum_name.data,
+            invalidEnumName
         );
 
         // Use VecForeach for iterating over entries
@@ -161,11 +161,11 @@ int main(int argc, char** argv) {
             const char* compareTemplate = "    if(ZstrCompareN(\"{}\", zstr, {}) == 0) {{return {};}}\n";
             // Store the length in a variable to avoid taking address of rvalue
             unsigned long long strLength = (unsigned long long)e.str.length;
-            StrWriteFmt(&code, compareTemplate, FMT(e.str.data), FMT(strLength), FMT(e.name.data));
+            StrWriteFmt(&code, compareTemplate, e.str.data, strLength, e.name.data);
         });
 
         const char* returnTemplate = "    return {};\n}}\n";
-        StrWriteFmt(&code, returnTemplate, FMT(invalidEnumName));
+        StrWriteFmt(&code, returnTemplate, invalidEnumName);
 
         const char* toZstrHeader =
             "///\n"
@@ -179,12 +179,12 @@ int main(int argc, char** argv) {
             "const char* {}ToZstr({} e) {{\n"
             "    switch(e) {{\n";
 
-        StrWriteFmt(&code, toZstrHeader, FMT(enum_name.data), FMT(enum_name.data), FMT(enum_name.data));
+        StrWriteFmt(&code, toZstrHeader, enum_name.data, enum_name.data, enum_name.data);
 
         // Use VecForeach for iterating over entries
         VecForeach(&entries, e, {
             const char* caseTemplate = "        case {} : {{return \"{}\";}}\n";
-            StrWriteFmt(&code, caseTemplate, FMT(e.name.data), FMT(e.str.data));
+            StrWriteFmt(&code, caseTemplate, e.name.data, e.str.data);
         });
 
         const char* defaultTemplate =
@@ -200,7 +200,7 @@ int main(int argc, char** argv) {
             nullStr = invalid_enum.str.data;
         }
 
-        StrWriteFmt(&code, defaultTemplate, FMT(nullStr));
+        StrWriteFmt(&code, defaultTemplate, nullStr);
     }
 
     if (output_filename) {

--- a/Include/Misra/Parsers/JSON.h
+++ b/Include/Misra/Parsers/JSON.h
@@ -577,7 +577,7 @@ StrIter JSkipValue(StrIter si);
                     break;                                                                                             \
                 }                                                                                                      \
                                                                                                                        \
-                LOG_INFO("User skipped reading of '{}' field in JSON object.", FMT(key));                              \
+                LOG_INFO("User skipped reading of '{}' field in JSON object.", key);                              \
                 si = read_si;                                                                                          \
             }                                                                                                          \
             StrDeinit(&key);                                                                                           \
@@ -591,7 +591,7 @@ StrIter JSkipValue(StrIter si);
         if (!failed) {                                                                                                 \
             char c = StrIterPeek(&si);                                                                                 \
             if (c != '}') {                                                                                            \
-                LOG_ERROR("Expected end of object '}' but found '{c}'", FMT(c));                                       \
+                LOG_ERROR("Expected end of object '}' but found '{c}'", c);                                       \
                 failed = true;                                                                                         \
                 si     = saved_si;                                                                                     \
                 break;                                                                                                 \

--- a/Include/Misra/Parsers/JSON.h
+++ b/Include/Misra/Parsers/JSON.h
@@ -577,7 +577,7 @@ StrIter JSkipValue(StrIter si);
                     break;                                                                                             \
                 }                                                                                                      \
                                                                                                                        \
-                LOG_INFO("User skipped reading of '{}' field in JSON object.", key);                              \
+                LOG_INFO("User skipped reading of '{}' field in JSON object.", key);                                   \
                 si = read_si;                                                                                          \
             }                                                                                                          \
             StrDeinit(&key);                                                                                           \
@@ -591,7 +591,7 @@ StrIter JSkipValue(StrIter si);
         if (!failed) {                                                                                                 \
             char c = StrIterPeek(&si);                                                                                 \
             if (c != '}') {                                                                                            \
-                LOG_ERROR("Expected end of object '}' but found '{c}'", c);                                       \
+                LOG_ERROR("Expected end of object '}' but found '{c}'", c);                                            \
                 failed = true;                                                                                         \
                 si     = saved_si;                                                                                     \
                 break;                                                                                                 \

--- a/Include/Misra/Std/Container/BitVec/Foreach.h
+++ b/Include/Misra/Std/Container/BitVec/Foreach.h
@@ -137,30 +137,30 @@
                 LOG_FATAL(                                                                                             \
                     "BitVec range overflow: End index {} exceeds bitvector length {}. "                                \
                     "If you intended to iterate over all bits, use BitVecForeach instead.",                            \
-                    FMT(_e),                                                                                           \
-                    FMT((bv)->length)                                                                                  \
+                    _e,                                                                                           \
+                    (bv)->length                                                                                  \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) >= (bv)->length) {                                                                                \
                 LOG_FATAL(                                                                                             \
                     "BitVec range overflow: Start index {} exceeds or equals bitvector length {}.",                    \
-                    FMT(_s),                                                                                           \
-                    FMT((bv)->length)                                                                                  \
+                    _s,                                                                                           \
+                    (bv)->length                                                                                  \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) > (_e)) {                                                                                         \
                 LOG_FATAL(                                                                                             \
                     "Invalid range: Start index {} must be less than or equal to end index {}.",                       \
-                    FMT(_s),                                                                                           \
-                    FMT(_e)                                                                                            \
+                    _s,                                                                                           \
+                    _e                                                                                            \
                 );                                                                                                     \
             }                                                                                                          \
             for ((idx) = (_s); (idx) < (_e); ++(idx)) {                                                                \
                 if ((idx) >= (bv)->length) {                                                                           \
                     LOG_FATAL(                                                                                         \
                         "BitVec range overflow: Index {} exceeds bitvector length {} during iteration.",               \
-                        FMT(idx),                                                                                      \
-                        FMT((bv)->length)                                                                              \
+                        idx,                                                                                      \
+                        (bv)->length                                                                              \
                     );                                                                                                 \
                 }                                                                                                      \
                 bool var = BitVecGet(bv, idx);                                                                         \

--- a/Include/Misra/Std/Container/BitVec/Foreach.h
+++ b/Include/Misra/Std/Container/BitVec/Foreach.h
@@ -137,30 +137,26 @@
                 LOG_FATAL(                                                                                             \
                     "BitVec range overflow: End index {} exceeds bitvector length {}. "                                \
                     "If you intended to iterate over all bits, use BitVecForeach instead.",                            \
-                    _e,                                                                                           \
-                    (bv)->length                                                                                  \
+                    _e,                                                                                                \
+                    (bv)->length                                                                                       \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) >= (bv)->length) {                                                                                \
                 LOG_FATAL(                                                                                             \
                     "BitVec range overflow: Start index {} exceeds or equals bitvector length {}.",                    \
-                    _s,                                                                                           \
-                    (bv)->length                                                                                  \
+                    _s,                                                                                                \
+                    (bv)->length                                                                                       \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) > (_e)) {                                                                                         \
-                LOG_FATAL(                                                                                             \
-                    "Invalid range: Start index {} must be less than or equal to end index {}.",                       \
-                    _s,                                                                                           \
-                    _e                                                                                            \
-                );                                                                                                     \
+                LOG_FATAL("Invalid range: Start index {} must be less than or equal to end index {}.", _s, _e);        \
             }                                                                                                          \
             for ((idx) = (_s); (idx) < (_e); ++(idx)) {                                                                \
                 if ((idx) >= (bv)->length) {                                                                           \
                     LOG_FATAL(                                                                                         \
                         "BitVec range overflow: Index {} exceeds bitvector length {} during iteration.",               \
-                        idx,                                                                                      \
-                        (bv)->length                                                                              \
+                        idx,                                                                                           \
+                        (bv)->length                                                                                   \
                     );                                                                                                 \
                 }                                                                                                      \
                 bool var = BitVecGet(bv, idx);                                                                         \

--- a/Include/Misra/Std/Container/Vec/Foreach.h
+++ b/Include/Misra/Std/Container/Vec/Foreach.h
@@ -235,30 +235,26 @@
                 LOG_FATAL(                                                                                             \
                     "Vector range overflow: End index %zu exceeds vector length %zu. "                                 \
                     "If you intended to iterate over all items, use VecForeach instead.",                              \
-                    _e,                                                                                           \
-                    (v)->length                                                                                   \
+                    _e,                                                                                                \
+                    (v)->length                                                                                        \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) >= (v)->length) {                                                                                 \
                 LOG_FATAL(                                                                                             \
                     "Vector range overflow: Start index %zu exceeds or equals vector length %zu.",                     \
-                    _s,                                                                                           \
-                    (v)->length                                                                                   \
+                    _s,                                                                                                \
+                    (v)->length                                                                                        \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) > (_e)) {                                                                                         \
-                LOG_FATAL(                                                                                             \
-                    "Invalid range: Start index %zu must be less than or equal to end index %zu.",                     \
-                    _s,                                                                                           \
-                    _e                                                                                            \
-                );                                                                                                     \
+                LOG_FATAL("Invalid range: Start index %zu must be less than or equal to end index %zu.", _s, _e);      \
             }                                                                                                          \
             for ((idx) = (_s); (idx) < (_e); ++(idx)) {                                                                \
                 if ((idx) >= (v)->length) {                                                                            \
                     LOG_FATAL(                                                                                         \
                         "Vector range overflow: Index %zu exceeds vector length %zu during iteration.",                \
-                        idx,                                                                                      \
-                        (v)->length                                                                               \
+                        idx,                                                                                           \
+                        (v)->length                                                                                    \
                     );                                                                                                 \
                 }                                                                                                      \
                 var = VecAt(v, idx);                                                                                   \
@@ -318,30 +314,26 @@
                 LOG_FATAL(                                                                                             \
                     "Vector range overflow: End index {} exceeds vector length {}. "                                   \
                     "If you intended to iterate over all items, use VecForeach instead.",                              \
-                    _e,                                                                                           \
-                    (v)->length                                                                                   \
+                    _e,                                                                                                \
+                    (v)->length                                                                                        \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) >= (v)->length) {                                                                                 \
                 LOG_FATAL(                                                                                             \
                     "Vector range overflow: Start index {} exceeds or equals vector length {}.",                       \
-                    _e,                                                                                           \
-                    (v)->length                                                                                   \
+                    _e,                                                                                                \
+                    (v)->length                                                                                        \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) > (_e)) {                                                                                         \
-                LOG_FATAL(                                                                                             \
-                    "Invalid range: Start index {} must be less than or equal to end index {}.",                       \
-                    _s,                                                                                           \
-                    _e                                                                                            \
-                );                                                                                                     \
+                LOG_FATAL("Invalid range: Start index {} must be less than or equal to end index {}.", _s, _e);        \
             }                                                                                                          \
             for ((idx) = (_s); (idx) < (_e); ++(idx)) {                                                                \
                 if ((idx) >= (v)->length) {                                                                            \
                     LOG_FATAL(                                                                                         \
                         "Vector range overflow: Index {} exceeds vector length {} during iteration.",                  \
-                        idx,                                                                                      \
-                        (v)->length                                                                               \
+                        idx,                                                                                           \
+                        (v)->length                                                                                    \
                     );                                                                                                 \
                 }                                                                                                      \
                 var = VecPtrAt(v, idx);                                                                                \

--- a/Include/Misra/Std/Container/Vec/Foreach.h
+++ b/Include/Misra/Std/Container/Vec/Foreach.h
@@ -235,30 +235,30 @@
                 LOG_FATAL(                                                                                             \
                     "Vector range overflow: End index %zu exceeds vector length %zu. "                                 \
                     "If you intended to iterate over all items, use VecForeach instead.",                              \
-                    FMT(_e),                                                                                           \
-                    FMT((v)->length)                                                                                   \
+                    _e,                                                                                           \
+                    (v)->length                                                                                   \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) >= (v)->length) {                                                                                 \
                 LOG_FATAL(                                                                                             \
                     "Vector range overflow: Start index %zu exceeds or equals vector length %zu.",                     \
-                    FMT(_s),                                                                                           \
-                    FMT((v)->length)                                                                                   \
+                    _s,                                                                                           \
+                    (v)->length                                                                                   \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) > (_e)) {                                                                                         \
                 LOG_FATAL(                                                                                             \
                     "Invalid range: Start index %zu must be less than or equal to end index %zu.",                     \
-                    FMT(_s),                                                                                           \
-                    FMT(_e)                                                                                            \
+                    _s,                                                                                           \
+                    _e                                                                                            \
                 );                                                                                                     \
             }                                                                                                          \
             for ((idx) = (_s); (idx) < (_e); ++(idx)) {                                                                \
                 if ((idx) >= (v)->length) {                                                                            \
                     LOG_FATAL(                                                                                         \
                         "Vector range overflow: Index %zu exceeds vector length %zu during iteration.",                \
-                        FMT(idx),                                                                                      \
-                        FMT((v)->length)                                                                               \
+                        idx,                                                                                      \
+                        (v)->length                                                                               \
                     );                                                                                                 \
                 }                                                                                                      \
                 var = VecAt(v, idx);                                                                                   \
@@ -318,30 +318,30 @@
                 LOG_FATAL(                                                                                             \
                     "Vector range overflow: End index {} exceeds vector length {}. "                                   \
                     "If you intended to iterate over all items, use VecForeach instead.",                              \
-                    FMT(_e),                                                                                           \
-                    FMT((v)->length)                                                                                   \
+                    _e,                                                                                           \
+                    (v)->length                                                                                   \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) >= (v)->length) {                                                                                 \
                 LOG_FATAL(                                                                                             \
                     "Vector range overflow: Start index {} exceeds or equals vector length {}.",                       \
-                    FMT(_e),                                                                                           \
-                    FMT((v)->length)                                                                                   \
+                    _e,                                                                                           \
+                    (v)->length                                                                                   \
                 );                                                                                                     \
             }                                                                                                          \
             if ((_s) > (_e)) {                                                                                         \
                 LOG_FATAL(                                                                                             \
                     "Invalid range: Start index {} must be less than or equal to end index {}.",                       \
-                    FMT(_s),                                                                                           \
-                    FMT(_e)                                                                                            \
+                    _s,                                                                                           \
+                    _e                                                                                            \
                 );                                                                                                     \
             }                                                                                                          \
             for ((idx) = (_s); (idx) < (_e); ++(idx)) {                                                                \
                 if ((idx) >= (v)->length) {                                                                            \
                     LOG_FATAL(                                                                                         \
                         "Vector range overflow: Index {} exceeds vector length {} during iteration.",                  \
-                        FMT(idx),                                                                                      \
-                        FMT((v)->length)                                                                               \
+                        idx,                                                                                      \
+                        (v)->length                                                                               \
                     );                                                                                                 \
                 }                                                                                                      \
                 var = VecPtrAt(v, idx);                                                                                \

--- a/Include/Misra/Std/Io.h
+++ b/Include/Misra/Std/Io.h
@@ -13,6 +13,11 @@
 // c
 #include <stdio.h>
 
+// REF : https://devblogs.microsoft.com/cppblog/announcing-full-support-for-a-c-c-conformant-preprocessor-in-msvc/
+#if defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL
+#    error "I need /Zc:prerocessor flag enabled in MSVC to compile IO code correctly"
+#endif
+
 ///
 /// Defines text alignment options for formatted output.
 ///

--- a/Include/Misra/Std/Io.h
+++ b/Include/Misra/Std/Io.h
@@ -177,17 +177,15 @@ static inline TypeSpecificIO TO_TYPE_SPECIFIC_IO_IMPL(TypeSpecificWriter w, Type
         )
 #endif
 
-#define FMT(x) x
-
 ///
 /// Print out a formatted string with rust-style placeholders
 /// to given string `o`.
 ///
-/// WARN: Directly passing literals like `FMT(1337)` is not supported, especially const char*
+/// WARN: Directly passing literals like `1337` is not supported, especially const char*
 ///       literals. For constants like integers, booleans, you can use `LVAL(r-value)`
-///       to convert an l-value to an r-value an then use in `FMT` like `FMT(LVAL(false))`
+///       to convert an l-value to an r-value an then use in `FMT` like `LVAL(false)`
 ///
-/// Takes in `TypeSpecificIO` structures as arguments. Use `FMT(.)`
+/// Takes in `TypeSpecificIO` structures as arguments. Use `.`
 /// to wrap any supported-type variable to it's `TypeSpecificIO` object.
 ///
 /// o[out]     : Contents appended to this string.
@@ -206,7 +204,7 @@ bool StrWriteFmtInternal(Str *o, const char *fmt, TypeSpecificIO *args, size arg
 /// Parse input string according to format string with rust-style placeholders,
 /// extracting values into provided `TypeSpecificIO` arguments.
 ///
-/// Takes in `TypeSpecificIO` structures as arguments. Use `FMT(.)` to wrap any
+/// Takes in `TypeSpecificIO` structures as arguments. Use `.` to wrap any
 /// supported-type variable to its `TypeSpecificIO` object.
 ///
 /// input[in]  : Input string to parse (null-terminated)
@@ -218,7 +216,7 @@ bool StrWriteFmtInternal(Str *o, const char *fmt, TypeSpecificIO *args, size arg
 ///   const char *input = "Count: 42, Name: Alice";
 ///   int count;
 ///   Str name;
-///   const char *remaining = StrReadFmt(input, "Count: {}, Name: {}", FMT(count), FMT(name));
+///   const char *remaining = StrReadFmt(input, "Count: {}, Name: {}", count, name);
 ///
 /// SUCCESS : After reading through `input`, returns back const char* to start reading from (from inside `input`)
 /// FAILURE : Returns NULL if `fmtstr` does not match with input. In any other case of error, does not return.
@@ -236,7 +234,7 @@ const char *StrReadFmtInternal(const char *input, const char *fmtstr, TypeSpecif
 /// argc[in]   : Number of `TypeSpecificIO` values in array.
 ///
 /// SUCCESS : Compares fmtstr with stream of characters in `stream` and reads values at placeholders.
-///           A valid value will be stored in `FMT(.)` arg provided.
+///           A valid value will be stored in `.` arg provided.
 /// FAILURE : Logs out error message and returns. If rollback is possible, then un-reads all the read data.
 ///           Restoring original state. Method can also abort if something really unexpected is encountered.
 ///           Returns `NULL` if format string does not match with input `stream`.
@@ -249,7 +247,8 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 /// Helper macro to append a comma after wrapping given argument in IOFMT
 /// Used in following macros
 ///
-#define IOFMT_APPEND_COMMA(x) IOFMT(LVAL(x)),
+#define IOFMT_LVAL_APPEND_COMMA(x) IOFMT(LVAL(x)),
+#define IOFMT_APPEND_COMMA(x)      IOFMT(x),
 
 ///
 /// Print out a formatted string with rust-style placeholders
@@ -257,13 +256,13 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 ///
 /// WARN: Directly passing literals like `StrWriteFmt(o, "{}", "literal")` for string literals
 ///       or `StrWriteFmt(o, "{}", 1337)` for integer literals might not work as expected
-///       without proper wrapping using `FMT()`. For constants like integers, booleans,
-///       you typically use `FMT(constant_variable)`.
+///       without proper wrapping using ``. For constants like integers, booleans,
+///       you typically use `constant_variable`.
 ///
 /// out[out]    : The Str object to which the formatted string will be appended.
 /// fmtstr[in]  : Format string with `{}` placeholders.
 /// ...[in]     : Variable number of arguments to replace the placeholders. Each argument
-///               should be wrapped with `FMT(variable)`.
+///               should be wrapped with `variable`.
 ///
 /// SUCCESS : Placeholders in `fmtstr` are replaced by the passed arguments, and the
 ///           result is appended to the `out` Str object.
@@ -279,7 +278,7 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
         input,                                                                                                         \
         fmtstr,                                                                                                        \
         ((TypeSpecificIO[]) {                                                                                          \
-            APPLY_MACRO_FOREACH(IOFMT_APPEND_COMMA, __VA_ARGS__) {NULL, NULL, NULL}                                    \
+            APPLY_MACRO_FOREACH(IOFMT_LVAL_APPEND_COMMA, __VA_ARGS__) {NULL, NULL, NULL}                               \
     })                                                                                                             \
     )
 #define StrWriteFmt_IMPL2(input, fmtstr, varr)                                                                         \
@@ -296,7 +295,7 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 /// input[in]   : Input string to parse (must be null-terminated).
 /// fmtstr[in]  : Format string with `{}` placeholders (must be null-terminated).
 /// ...[in]     : Variable number of arguments that will receive the parsed values. Each
-///               argument should be a modifiable l-value wrapped with `FMT(&variable)`.
+///               argument should be a modifiable l-value wrapped with `&variable`.
 ///
 /// SUCCESS : Returns a `const char*` pointing to the beginning of the unparsed portion
 ///           of the `input` string after successful parsing.
@@ -328,10 +327,10 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 /// fmtstr[in]  : Format string to be used for reading. This must exactly describe the
 ///               expected input format in the stream.
 /// ...[in]     : Variable number of arguments that will receive the read values. Each
-///               argument should be a modifiable l-value wrapped with `FMT(&variable)`.
+///               argument should be a modifiable l-value wrapped with `&variable`.
 ///
 /// SUCCESS : Attempts to match `fmtstr` with the stream of characters in `stream` and
-///           reads values into the provided arguments wrapped with `FMT()`.
+///           reads values into the provided arguments wrapped with ``.
 /// FAILURE : Failure occurs within `FReadFmtInternal`. Refer to its documentation for
 ///           details on failure behavior (logs error message and returns, may rollback
 ///           read data, or abort in unexpected situations).
@@ -361,7 +360,7 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 /// stream[in]  : Pointer to the `FILE` stream to write to.
 /// fmtstr[in]  : Format string with `{}` placeholders.
 /// ...[in]     : Variable number of arguments to replace the placeholders. Each argument
-///               should be wrapped with `FMT(variable)`.
+///               should be wrapped with `variable`.
 ///
 /// SUCCESS : Placeholders in `fmtstr` are replaced by the passed arguments, and the
 ///           resulting formatted string is written to the specified `stream`.
@@ -377,7 +376,7 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
         stream,                                                                                                        \
         fmtstr,                                                                                                        \
         ((TypeSpecificIO[]) {                                                                                          \
-            APPLY_MACRO_FOREACH(IOFMT_APPEND_COMMA, __VA_ARGS__) {NULL, NULL, NULL}                                    \
+            APPLY_MACRO_FOREACH(IOFMT_LVAL_APPEND_COMMA, __VA_ARGS__) {NULL, NULL, NULL}                               \
     })                                                                                                             \
     )
 #define FWriteFmt_IMPL2(stream, fmtstr, varr)                                                                          \
@@ -398,7 +397,7 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 /// stream[in]  : Pointer to the `FILE` stream to write to.
 /// fmtstr[in]  : Format string with `{}` placeholders.
 /// ...[in]     : Variable number of arguments to replace the placeholders. Each argument
-///               should be wrapped with `FMT(variable)`.
+///               should be wrapped with `variable`.
 ///
 /// SUCCESS : Placeholders in `fmtstr` are replaced by the passed arguments, and the
 ///           resulting formatted string followed by a newline is written to the `stream`.
@@ -414,7 +413,7 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
         stream,                                                                                                        \
         fmtstr,                                                                                                        \
         ((TypeSpecificIO[]) {                                                                                          \
-            APPLY_MACRO_FOREACH(IOFMT_APPEND_COMMA, __VA_ARGS__) {NULL, NULL, NULL}                                    \
+            APPLY_MACRO_FOREACH(IOFMT_LVAL_APPEND_COMMA, __VA_ARGS__) {NULL, NULL, NULL}                               \
     })                                                                                                             \
     )
 #define FWriteFmtLn_IMPL2(stream, fmtstr, varr)                                                                        \
@@ -434,7 +433,7 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 ///
 /// fmtstr[in]  : Format string with `{}` placeholders.
 /// ...[in]     : Variable number of arguments to replace the placeholders. Each argument
-///               should be wrapped with `FMT(variable)`.
+///               should be wrapped with `variable`.
 ///
 /// SUCCESS : Placeholders in `fmtstr` are replaced by the passed arguments, and the
 ///           resulting formatted string is written to `stdout`.
@@ -452,7 +451,7 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 ///
 /// fmtstr[in]  : Format string with `{}` placeholders.
 /// ...[in]     : Variable number of arguments to replace the placeholders. Each argument
-///               should be wrapped with `FMT(variable)`.
+///               should be wrapped with `variable`.
 ///
 /// SUCCESS : Placeholders in `fmtstr` are replaced by the passed arguments, and the
 ///           resulting formatted string followed by a newline is written to `stdout`.
@@ -471,10 +470,10 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 /// fmtstr[in]  : Format string to be used for reading. This must exactly describe the
 ///               expected input format from `stdin`.
 /// ...[in]     : Variable number of arguments that will receive the read values. Each
-///               argument should be a modifiable l-value wrapped with `FMT(&variable)`.
+///               argument should be a modifiable l-value wrapped with `&variable`.
 ///
 /// SUCCESS : Attempts to match `fmtstr` with the input from `stdin` and reads values
-///           into the provided arguments wrapped with `FMT()`.
+///           into the provided arguments wrapped with ``.
 /// FAILURE : Failure occurs within `FReadFmtInternal`. Refer to its documentation for
 ///           details on failure behavior (logs error message and returns, may rollback
 ///           read data, or abort in unexpected situations).

--- a/Include/Misra/Std/Io.h
+++ b/Include/Misra/Std/Io.h
@@ -109,6 +109,12 @@ typedef struct TypeSpecificIO {
     void              *data;
 } TypeSpecificIO;
 
+#ifdef __cplusplus
+#    define EMPTY_TYPE_SPECIFIC_IO() (TypeSpecificIO {NULL, NULL, NULL})
+#else
+#    define EMPTY_TYPE_SPECIFIC_IO() ((TypeSpecificIO) {NULL, NULL, NULL})
+#endif
+
 static inline TypeSpecificIO TO_TYPE_SPECIFIC_IO_IMPL(TypeSpecificWriter w, TypeSpecificReader r, void *d) {
     return (TypeSpecificIO) {.writer = w, .reader = r, .data = d};
 }
@@ -117,7 +123,7 @@ static inline TypeSpecificIO TO_TYPE_SPECIFIC_IO_IMPL(TypeSpecificWriter w, Type
     TO_TYPE_SPECIFIC_IO_IMPL((TypeSpecificWriter)_write_##T, (TypeSpecificReader)_read_##T, (d))
 
 #if defined(_MSC_VER) || defined(__MSC_VER)
-#    define FMT(x)                                                                                                     \
+#    define IOFMT(x)                                                                                                   \
         _Generic(                                                                                                      \
             (x),                                                                                                       \
             Str: TO_TYPE_SPECIFIC_IO(Str, &(x)),                                                                       \
@@ -148,7 +154,7 @@ static inline TypeSpecificIO TO_TYPE_SPECIFIC_IO_IMPL(TypeSpecificWriter w, Type
 /// FAILURE: Returns unsupported type handler for unknown types
 ///
 /// TAGS: Macro, TypeDispatch, Generic, I/O, Format
-#    define FMT(x)                                                                                                     \
+#    define IOFMT(x)                                                                                                   \
         _Generic(                                                                                                      \
             (x),                                                                                                       \
             Str: TO_TYPE_SPECIFIC_IO(Str, (void *)&(x)),                                                               \
@@ -170,6 +176,8 @@ static inline TypeSpecificIO TO_TYPE_SPECIFIC_IO_IMPL(TypeSpecificWriter w, Type
             default: TO_TYPE_SPECIFIC_IO(UnsupportedType, NULL)                                                        \
         )
 #endif
+
+#define FMT(x) x
 
 ///
 /// Print out a formatted string with rust-style placeholders
@@ -238,6 +246,12 @@ const char *StrReadFmtInternal(const char *input, const char *fmtstr, TypeSpecif
 void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, size argc);
 
 ///
+/// Helper macro to append a comma after wrapping given argument in IOFMT
+/// Used in following macros
+///
+#define IOFMT_APPEND_COMMA(x) IOFMT(LVAL(x)),
+
+///
 /// Print out a formatted string with rust-style placeholders
 /// to given string `o`. This is a macro wrapper around StrWriteFmtImpl.
 ///
@@ -259,8 +273,15 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 /// TAGS: Macro, Wrapper, Format, I/O
 ///
 // #define StrWriteFmt(out, ...) StrWriteFmtImpl(out, __VA_ARGS__, (TypeSpecificIO) {NULL, NULL, NULL})
-#define StrWriteFmt(out, ...)                 StrWriteFmt_IMPL1(out, __VA_ARGS__, (TypeSpecificIO) {NULL, NULL, NULL})
-#define StrWriteFmt_IMPL1(input, fmtstr, ...) StrWriteFmt_IMPL2(input, fmtstr, ((TypeSpecificIO[]) {__VA_ARGS__}))
+#define StrWriteFmt(out, ...) StrWriteFmt_IMPL1(out, __VA_ARGS__)
+#define StrWriteFmt_IMPL1(input, fmtstr, ...)                                                                          \
+    StrWriteFmt_IMPL2(                                                                                                 \
+        input,                                                                                                         \
+        fmtstr,                                                                                                        \
+        ((TypeSpecificIO[]) {                                                                                          \
+            APPLY_MACRO_FOREACH(IOFMT_APPEND_COMMA, __VA_ARGS__) {NULL, NULL, NULL}                                    \
+    })                                                                                                             \
+    )
 #define StrWriteFmt_IMPL2(input, fmtstr, varr)                                                                         \
     do {                                                                                                               \
         TypeSpecificIO *argv_##__LINE__ = &(varr)[0];                                                                  \
@@ -284,8 +305,15 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 ///
 /// TAGS: Macro, Wrapper, Format, Parsing, I/O
 ///
-#define StrReadFmt(input, ...)               StrReadFmt_IMPL1(input, __VA_ARGS__, (TypeSpecificIO) {NULL, NULL, NULL})
-#define StrReadFmt_IMPL1(input, fmtstr, ...) StrReadFmt_IMPL2(input, fmtstr, ((TypeSpecificIO[]) {__VA_ARGS__}))
+#define StrReadFmt(input, ...) StrReadFmt_IMPL1(input, __VA_ARGS__)
+#define StrReadFmt_IMPL1(input, fmtstr, ...)                                                                           \
+    StrReadFmt_IMPL2(                                                                                                  \
+        input,                                                                                                         \
+        fmtstr,                                                                                                        \
+        ((TypeSpecificIO[]) {                                                                                          \
+            APPLY_MACRO_FOREACH(IOFMT_APPEND_COMMA, __VA_ARGS__) {NULL, NULL, NULL}                                    \
+    })                                                                                                             \
+    )
 #define StrReadFmt_IMPL2(input, fmtstr, varr)                                                                          \
     do {                                                                                                               \
         TypeSpecificIO *argv_##__LINE__ = &(varr)[0];                                                                  \
@@ -310,8 +338,15 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 ///
 /// TAGS: Macro, Wrapper, File, I/O
 ///
-#define FReadFmt(file, ...)               FReadFmt_IMPL1(file, __VA_ARGS__, (TypeSpecificIO) {NULL, NULL, NULL})
-#define FReadFmt_IMPL1(file, fmtstr, ...) FReadFmt_IMPL2(file, fmtstr, ((TypeSpecificIO[]) {__VA_ARGS__}))
+#define FReadFmt(file, ...) FReadFmt_IMPL1(file, __VA_ARGS__)
+#define FReadFmt_IMPL1(file, fmtstr, ...)                                                                              \
+    FReadFmt_IMPL2(                                                                                                    \
+        file,                                                                                                          \
+        fmtstr,                                                                                                        \
+        ((TypeSpecificIO[]) {                                                                                          \
+            APPLY_MACRO_FOREACH(IOFMT_APPEND_COMMA, __VA_ARGS__) {NULL, NULL, NULL}                                    \
+    })                                                                                                             \
+    )
 #define FReadFmt_IMPL2(file, fmtstr, varr)                                                                             \
     do {                                                                                                               \
         TypeSpecificIO *argv_##__LINE__ = &(varr)[0];                                                                  \
@@ -336,8 +371,15 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 ///
 /// TAGS: Macro, Wrapper, File, I/O
 ///
-#define FWriteFmt(stream, ...)               FWriteFmt_IMPL1(stream, __VA_ARGS__, (TypeSpecificIO) {NULL, NULL, NULL})
-#define FWriteFmt_IMPL1(stream, fmtstr, ...) FWriteFmt_IMPL2(stream, fmtstr, ((TypeSpecificIO[]) {__VA_ARGS__}))
+#define FWriteFmt(stream, ...) FWriteFmt_IMPL1(stream, __VA_ARGS__)
+#define FWriteFmt_IMPL1(stream, fmtstr, ...)                                                                           \
+    FWriteFmt_IMPL2(                                                                                                   \
+        stream,                                                                                                        \
+        fmtstr,                                                                                                        \
+        ((TypeSpecificIO[]) {                                                                                          \
+            APPLY_MACRO_FOREACH(IOFMT_APPEND_COMMA, __VA_ARGS__) {NULL, NULL, NULL}                                    \
+    })                                                                                                             \
+    )
 #define FWriteFmt_IMPL2(stream, fmtstr, varr)                                                                          \
     do {                                                                                                               \
         TypeSpecificIO *argv_##__LINE__ = &(varr)[0];                                                                  \
@@ -366,8 +408,15 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 ///
 /// TAGS: Macro, Wrapper, File, I/O
 ///
-#define FWriteFmtLn(stream, ...)               FWriteFmtLn_IMPL1(stream, __VA_ARGS__, (TypeSpecificIO) {NULL, NULL, NULL})
-#define FWriteFmtLn_IMPL1(stream, fmtstr, ...) FWriteFmtLn_IMPL2(stream, fmtstr, ((TypeSpecificIO[]) {__VA_ARGS__}))
+#define FWriteFmtLn(stream, ...) FWriteFmtLn_IMPL1(stream, __VA_ARGS__)
+#define FWriteFmtLn_IMPL1(stream, fmtstr, ...)                                                                         \
+    FWriteFmtLn_IMPL2(                                                                                                 \
+        stream,                                                                                                        \
+        fmtstr,                                                                                                        \
+        ((TypeSpecificIO[]) {                                                                                          \
+            APPLY_MACRO_FOREACH(IOFMT_APPEND_COMMA, __VA_ARGS__) {NULL, NULL, NULL}                                    \
+    })                                                                                                             \
+    )
 #define FWriteFmtLn_IMPL2(stream, fmtstr, varr)                                                                        \
     do {                                                                                                               \
         TypeSpecificIO *argv_##__LINE__ = &(varr)[0];                                                                  \

--- a/Include/Misra/Types.h
+++ b/Include/Misra/Types.h
@@ -606,9 +606,7 @@ typedef i8 bool;
 ///
 #define TRICK_PARENS ()
 
-#define TRICK_EXPAND(...)  TRICK_EXPAND6(TRICK_EXPAND6(TRICK_EXPAND6(TRICK_EXPAND6(__VA_ARGS__))))
-#define TRICK_EXPAND6(...) TRICK_EXPAND5(TRICK_EXPAND5(TRICK_EXPAND5(TRICK_EXPAND5(__VA_ARGS__))))
-#define TRICK_EXPAND5(...) TRICK_EXPAND4(TRICK_EXPAND4(TRICK_EXPAND4(TRICK_EXPAND4(__VA_ARGS__))))
+#define TRICK_EXPAND(...)  TRICK_EXPAND4(TRICK_EXPAND4(TRICK_EXPAND4(TRICK_EXPAND4(__VA_ARGS__))))
 #define TRICK_EXPAND4(...) TRICK_EXPAND3(TRICK_EXPAND3(TRICK_EXPAND3(TRICK_EXPAND3(__VA_ARGS__))))
 #define TRICK_EXPAND3(...) TRICK_EXPAND2(TRICK_EXPAND2(TRICK_EXPAND2(TRICK_EXPAND2(__VA_ARGS__))))
 #define TRICK_EXPAND2(...) TRICK_EXPAND1(TRICK_EXPAND1(TRICK_EXPAND1(TRICK_EXPAND1(__VA_ARGS__))))
@@ -619,7 +617,7 @@ typedef i8 bool;
 ///
 /// This is a macro trick to apply a given macro on a variadic argument list
 /// one by one. The only limitiation here is that we cannot expand more than
-/// 4096 times for the moment. To make it do more than that, we just need to add
+/// 256 times for the moment. To make it do more than that, we just need to add
 /// one more line to the EXPAND macros
 ///
 /// Also, if you have more than 20-30 arguments in your format strings, you should

--- a/Include/Misra/Types.h
+++ b/Include/Misra/Types.h
@@ -601,4 +601,44 @@ typedef i8 bool;
 #    define FORMAT_STRING(fmt_pos, va_arg_pos) __attribute((format(printf, fmt_pos, va_arg_pos)))
 #endif
 
+///
+/// Part of the parenthesis trick to delay text generation
+///
+#define TRICK_PARENS ()
+
+#define TRICK_EXPAND(...)  TRICK_EXPAND6(TRICK_EXPAND6(TRICK_EXPAND6(TRICK_EXPAND6(__VA_ARGS__))))
+#define TRICK_EXPAND6(...) TRICK_EXPAND5(TRICK_EXPAND5(TRICK_EXPAND5(TRICK_EXPAND5(__VA_ARGS__))))
+#define TRICK_EXPAND5(...) TRICK_EXPAND4(TRICK_EXPAND4(TRICK_EXPAND4(TRICK_EXPAND4(__VA_ARGS__))))
+#define TRICK_EXPAND4(...) TRICK_EXPAND3(TRICK_EXPAND3(TRICK_EXPAND3(TRICK_EXPAND3(__VA_ARGS__))))
+#define TRICK_EXPAND3(...) TRICK_EXPAND2(TRICK_EXPAND2(TRICK_EXPAND2(TRICK_EXPAND2(__VA_ARGS__))))
+#define TRICK_EXPAND2(...) TRICK_EXPAND1(TRICK_EXPAND1(TRICK_EXPAND1(TRICK_EXPAND1(__VA_ARGS__))))
+#define TRICK_EXPAND1(...) __VA_ARGS__
+
+///
+/// Expand variadic argument list for given macro for each element one by one.
+///
+/// This is a macro trick to apply a given macro on a variadic argument list
+/// one by one. The only limitiation here is that we cannot expand more than
+/// 4096 times for the moment. To make it do more than that, we just need to add
+/// one more line to the EXPAND macros
+///
+/// Also, if you have more than 20-30 arguments in your format strings, you should
+/// seriously consider whether you're doing something wrong
+///
+/// Reference : https://www.scs.stanford.edu/~dm/blog/va-opt.html
+///
+#define APPLY_MACRO_FOREACH(macro, ...) __VA_OPT__(TRICK_EXPAND(APPLY_MACRO_FOREACH_HELPER(macro, __VA_ARGS__)))
+
+///
+/// Helper macro to apply given macro to the very first argument in list of variadic macro arguments
+/// Then expands to applying the same macro to more arguments only if there are more
+///
+#define APPLY_MACRO_FOREACH_HELPER(macro, a1, ...)                                                                     \
+    macro(a1) __VA_OPT__(APPLY_MACRO_FOREACH_AGAIN TRICK_PARENS(macro, __VA_ARGS__))
+
+///
+/// Helper macro to delay evaluation in text generation (pre-processing) phase of macro
+///
+#define APPLY_MACRO_FOREACH_AGAIN() APPLY_MACRO_FOREACH_HELPER
+
 #endif // MISRA_TYPES_H

--- a/README.md
+++ b/README.md
@@ -198,12 +198,11 @@ int main() {
     // Basic formatting with direct values
     int count = 42;
     const char* name = "Test";
-    StrWriteFmt(&output, "Count: {}, Name: {}\n", 
-                FMT(count), FMT(name));  // Pass values directly, not pointers
+    StrWriteFmt(&output, "Count: {}, Name: {}\n", count, name);  // Pass values directly, not pointers
     
     // Format with alignment and hex
     u32 hex_val = 0xDEADBEEF;
-    StrWriteFmt(&output, "Hex: {X}\n", FMT(hex_val));
+    StrWriteFmt(&output, "Hex: {X}\n", hex_val);
     
     // Read formatted input
     const char* input = "Count: 42, Name: Test";
@@ -211,19 +210,16 @@ int main() {
     Str read_name = StrInit();
     
     // For reading, we pass the variables directly
-    StrReadFmt(input, "Count: {}, Name: {}", 
-               FMT(read_count), FMT(read_name));  // No & operator needed
+    StrReadFmt(input, "Count: {}, Name: {}", read_count, read_name);  // No & operator needed
     
     // Multiple value types
     float pi = 3.14159f;
     u64 big_num = 123456789ULL;
-    StrWriteFmt(&output, 
-                "Float: {.2f}, Integer: {}, Hex: {x}\n",
-                FMT(pi), FMT(big_num), FMT(big_num));
+    StrWriteFmt(&output, "Float: {.2f}, Integer: {}, Hex: {x}\n", pi, big_num, big_num);
     
     // String formatting
     Str hello = StrInitFromZstr("Hello");
-    StrWriteFmt(&output, "String: {}\n", FMT(hello));  // Pass Str directly
+    StrWriteFmt(&output, "String: {}\n", hello);  // Pass Str directly
     
     // Cleanup
     StrDeinit(&output);
@@ -392,24 +388,24 @@ int main() {
 
 ## Format Specifiers
 
-The library supports Rust-style format strings with placeholders in the form `{}` or `{pecifier}`. Arguments are passed using the `FMT()` macro, which automatically determines the correct type handling.
+The library supports Rust-style format strings with placeholders in the form `{}` or `{pecifier}`.
 
-### Important: Understanding the FMT Macro
+### Important: Understanding Supported Argument Format
 
-The `FMT()` macro uses `_Generic` for compile-time type dispatching. Here's what works and what doesn't:
+The macro-tricks use `_Generic` for compile-time type specific io dispatching. Here's what works and what doesn't:
 
 #### ❌ What Doesn't Work
 
 ```c
 // String literals (array types like char[6] not handled by _Generic)
-StrWriteFmt(&output, "Hello, {}!", FMT("world"));  // ERROR: char[6] not in _Generic cases
+StrWriteFmt(&output, "Hello, {}!", "world");  // ERROR: char[6] not in _Generic cases
 
 // Any char array types are not handled
-char buffer[20] = "Hello";                         // Type: char[20] 
-StrWriteFmt(&output, "Message: {}", FMT(buffer));  // ERROR: char[20] not in _Generic cases
+char buffer[20] = "Hello";                    // Type: char[20] 
+StrWriteFmt(&output, "Message: {}", buffer);  // ERROR: char[20] not in _Generic cases
 
-const char name[] = "Alice";                       // Type: const char[6]
-StrWriteFmt(&output, "Name: {}", FMT(name));       // ERROR: const char[6] not in _Generic cases
+const char name[] = "Alice";                  // Type: const char[6]
+StrWriteFmt(&output, "Name: {}", name);       // ERROR: const char[6] not in _Generic cases
 ```
 
 #### ✅ What Works Perfectly
@@ -418,21 +414,21 @@ StrWriteFmt(&output, "Name: {}", FMT(name));       // ERROR: const char[6] not i
 // const char* variables (pointer type matches _Generic case)
 const char* title = "Mr.";
 const char* surname = "Smith";
-StrWriteFmt(&output, "{} {}", FMT(title), FMT(surname));  // ✅ Works great!
+StrWriteFmt(&output, "{} {}", title, surname);  // ✅ Works great!
 
 // char* variables (pointer type matches _Generic case)
 char* dynamic_str = malloc(50);
 strcpy(dynamic_str, "Dynamic");
-StrWriteFmt(&output, "Value: {}", FMT(dynamic_str));      // ✅ Works perfectly!
+StrWriteFmt(&output, "Value: {}", dynamic_str);      // ✅ Works perfectly!
 
 // Str objects (library's string type)
 Str greeting = StrInitFromZstr("Welcome");
-StrWriteFmt(&output, "Message: {}", FMT(greeting));
+StrWriteFmt(&output, "Message: {}", greeting);
 
 // Primitive types (all handled by _Generic)
 int number = 42;
 float pi = 3.14f;
-StrWriteFmt(&output, "Number: {}, Pi: {.2}", FMT(number), FMT(pi));
+StrWriteFmt(&output, "Number: {}, Pi: {.2}", number, pi);
 ```
 
 #### 💡 Best Practices
@@ -444,25 +440,25 @@ const char* version = "1.0.0";           // ✅ char* pointer types work!
 
 // For dynamic strings, use Str objects or char* pointers:
 Str user_input = StrInit();
-StrReadFmt(input_line, "Name: {}", FMT(user_input));
+StrReadFmt(input_line, "Name: {}", user_input);
 
 char* allocated = malloc(100);
 strcpy(allocated, "Dynamic content");
-StrWriteFmt(&message, "Content: {}", FMT(allocated));     // ✅ char* works!
+StrWriteFmt(&message, "Content: {}", allocated);     // ✅ char* works!
 
 // For function parameters accepting strings:
 void log_message(const char* msg) {                      // ✅ const char* parameter
-    StrWriteFmt(&log_output, "[LOG] {}", FMT(msg));       // ✅ Works perfectly!
+    StrWriteFmt(&log_output, "[LOG] {}", msg);       // ✅ Works perfectly!
 }
 
 void process_buffer(char* buffer) {                      // ✅ char* parameter  
-    StrWriteFmt(&output, "Processing: {}", FMT(buffer));  // ✅ Works great!
+    StrWriteFmt(&output, "Processing: {}", buffer);  // ✅ Works great!
 }
 ```
 
 #### 🔧 Technical Explanation
 
-The `FMT()` macro uses `_Generic` which only handles these specific types:
+The macro-tricks use `_Generic` which only handles these specific types:
 - `const char*` ✅
 - `char*` ✅  
 - `Str` ✅
@@ -562,7 +558,7 @@ Precision is ignored if specified when reading/writing raw data.
 // Correct usage with const char*
 const char* greeting = "Hello";
 const char* subject = "world";
-StrWriteFmt(&output, "{}, {}!", FMT(greeting), FMT(subject));  // "Hello, world!"
+StrWriteFmt(&output, "{}, {}!", greeting, subject);  // "Hello, world!"
 
 // Escaped braces
 StrWriteFmt(&output, "{{Hello}}");  // "{Hello}"
@@ -574,12 +570,12 @@ StrWriteFmt(&output, "{{Hello}}");  // "{Hello}"
 const char* str = "Hello";  // const char* variable
 
 // Basic string
-StrWriteFmt(&output, "{}", FMT(str));  // "Hello"
+StrWriteFmt(&output, "{}", str);  // "Hello"
 
 // String with width and alignment
-StrWriteFmt(&output, "{>10}", FMT(str));  // "     Hello"
-StrWriteFmt(&output, "{<10}", FMT(str));  // "Hello     "
-StrWriteFmt(&output, "{^10}", FMT(str));  // "  Hello   "
+StrWriteFmt(&output, "{>10}", str);  // "     Hello"
+StrWriteFmt(&output, "{<10}", str);  // "Hello     "
+StrWriteFmt(&output, "{^10}", str);  // "  Hello   "
 ```
 
 #### Integer Formatting
@@ -588,25 +584,25 @@ StrWriteFmt(&output, "{^10}", FMT(str));  // "  Hello   "
 i32 val = 42;
 
 // Default decimal
-StrWriteFmt(&output, "{}", FMT(val));  // "42"
+StrWriteFmt(&output, "{}", val);  // "42"
 
 // Hexadecimal
 u32 hex_val = 0xDEADBEEF;
-StrWriteFmt(&output, "{}", FMT(hex_val));  // "0xdeadbeef"
-StrWriteFmt(&output, "{}", FMT(hex_val));  // "0xDEADBEEF"
+StrWriteFmt(&output, "{}", hex_val);  // "0xdeadbeef"
+StrWriteFmt(&output, "{}", hex_val);  // "0xDEADBEEF"
 
 // Binary
 u8 bin_val = 0xA5;  // 10100101 in binary
-StrWriteFmt(&output, "{}", FMT(bin_val));  // "0b10100101"
+StrWriteFmt(&output, "{}", bin_val);  // "0b10100101"
 
 // Octal
 u16 oct_val = 0777;
-StrWriteFmt(&output, "{}", FMT(oct_val));  // "0o777"
+StrWriteFmt(&output, "{}", oct_val);  // "0o777"
 
 // Width and alignment with numbers
-StrWriteFmt(&output, "{}", FMT(val));   // "   42" (right-aligned)
-StrWriteFmt(&output, "{<5}", FMT(val));  // "42   " (left-aligned)
-StrWriteFmt(&output, "{^5}", FMT(val));  // " 42  " (center-aligned)
+StrWriteFmt(&output, "{}", val);   // "   42" (right-aligned)
+StrWriteFmt(&output, "{<5}", val);  // "42   " (left-aligned)
+StrWriteFmt(&output, "{^5}", val);  // " 42  " (center-aligned)
 ```
 
 #### Character Formatting
@@ -618,21 +614,21 @@ The character format specifiers (`c`, `a`, `A`) work with integer types, treatin
 u8 upper_char = 'M';
 u8 lower_char = 'm';
 
-StrWriteFmt(&output, "{}", FMT(upper_char));  // "M" (preserve case)
-StrWriteFmt(&output, "{}", FMT(upper_char));  // "m" (force lowercase)
-StrWriteFmt(&output, "{}", FMT(lower_char));  // "M" (force uppercase)
+StrWriteFmt(&output, "{}", upper_char);  // "M" (preserve case)
+StrWriteFmt(&output, "{}", upper_char);  // "m" (force lowercase)
+StrWriteFmt(&output, "{}", lower_char);  // "M" (force uppercase)
 
 // Multi-byte integers (interpreted as character sequences)
 u16 u16_value = ('A' << 8) | 'B'; // "AB" in big-endian
-StrWriteFmt(&output, "{}", FMT(u16_value));  // "AB" (preserve case)
-StrWriteFmt(&output, "{}", FMT(u16_value));  // "ab" (force lowercase)
-StrWriteFmt(&output, "{}", FMT(u16_value));  // "AB" (force uppercase)
+StrWriteFmt(&output, "{}", u16_value);  // "AB" (preserve case)
+StrWriteFmt(&output, "{}", u16_value);  // "ab" (force lowercase)
+StrWriteFmt(&output, "{}", u16_value);  // "AB" (force uppercase)
 
 // Works with u32 and u64 as well, treating them as byte sequences
 u32 u32_value = ('H' << 24) | ('i' << 16) | ('!' << 8) | '!';
-StrWriteFmt(&output, "{}", FMT(u32_value));  // "Hi!!" (preserve case)
-StrWriteFmt(&output, "{}", FMT(u32_value));  // "hi!!" (force lowercase)
-StrWriteFmt(&output, "{}", FMT(u32_value));  // "HI!!" (force uppercase)
+StrWriteFmt(&output, "{}", u32_value);  // "Hi!!" (preserve case)
+StrWriteFmt(&output, "{}", u32_value);  // "hi!!" (force lowercase)
+StrWriteFmt(&output, "{}", u32_value);  // "HI!!" (force uppercase)
 ```
 
 #### String Case Formatting
@@ -642,14 +638,14 @@ Character format specifiers also work with strings:
 ```c
 const char* mixed_case = "MiXeD CaSe";
 
-StrWriteFmt(&output, "{}", FMT(mixed_case));  // "MiXeD CaSe" (preserve case)
-StrWriteFmt(&output, "{}", FMT(mixed_case));  // "mixed case" (force lowercase)
-StrWriteFmt(&output, "{}", FMT(mixed_case));  // "MIXED CASE" (force uppercase)
+StrWriteFmt(&output, "{}", mixed_case);  // "MiXeD CaSe" (preserve case)
+StrWriteFmt(&output, "{}", mixed_case);  // "mixed case" (force lowercase)
+StrWriteFmt(&output, "{}", mixed_case);  // "MIXED CASE" (force uppercase)
 
 // Also works with Str objects
 Str s = StrInitFromZstr("Hello World");
-StrWriteFmt(&output, "{}", FMT(s));  // "hello world"
-StrWriteFmt(&output, "{}", FMT(s));  // "HELLO WORLD"
+StrWriteFmt(&output, "{}", s);  // "hello world"
+StrWriteFmt(&output, "{}", s);  // "HELLO WORLD"
 ```
 
 #### Floating-Point Formatting
@@ -658,27 +654,27 @@ StrWriteFmt(&output, "{}", FMT(s));  // "HELLO WORLD"
 f64 pi = 3.14159265359;
 
 // Default precision (6 decimal places)
-StrWriteFmt(&output, "{}", FMT(pi));  // "3.141593"
+StrWriteFmt(&output, "{}", pi);  // "3.141593"
 
 // Custom precision
-StrWriteFmt(&output, "{.2}", FMT(pi));   // "3.14"
-StrWriteFmt(&output, "{.0}", FMT(pi));   // "3"
-StrWriteFmt(&output, "{.10}", FMT(pi));  // "3.1415926536"
+StrWriteFmt(&output, "{.2}", pi);   // "3.14"
+StrWriteFmt(&output, "{.0}", pi);   // "3"
+StrWriteFmt(&output, "{.10}", pi);  // "3.1415926536"
 
 // Scientific notation
-StrWriteFmt(&output, "{}", FMT(123.456));  // "1.235e+02"
-StrWriteFmt(&output, "{}", FMT(123.456));  // "1.235E+02"
+StrWriteFmt(&output, "{}", 123.456);  // "1.235e+02"
+StrWriteFmt(&output, "{}", 123.456);  // "1.235E+02"
 
 // Custom precision with scientific notation
-StrWriteFmt(&output, "{.3e}", FMT(123.456));  // "1.235e+02"
+StrWriteFmt(&output, "{.3e}", 123.456);  // "1.235e+02"
 
 // Special values
 f64 pos_inf = INFINITY;
 f64 neg_inf = -INFINITY;
 f64 nan_val = NAN;
-StrWriteFmt(&output, "{}", FMT(pos_inf));  // "inf"
-StrWriteFmt(&output, "{}", FMT(neg_inf));  // "-inf"
-StrWriteFmt(&output, "{}", FMT(nan_val));  // "nan"
+StrWriteFmt(&output, "{}", pos_inf);  // "inf"
+StrWriteFmt(&output, "{}", neg_inf);  // "-inf"
+StrWriteFmt(&output, "{}", nan_val);  // "nan"
 ```
 
 ### Reading Values
@@ -688,38 +684,38 @@ The library also supports parsing values from strings using the same format spec
 ```c
 // Reading integers
 i32 num = 0;
-StrReadFmt("42", "{}", FMT(num));  // num = 42
+StrReadFmt("42", "{}", num);  // num = 42
 
 // Reading hexadecimal (auto-detected with 0x prefix)
 u32 hex_val = 0;
-StrReadFmt("0xdeadbeef", "{}", FMT(hex_val));  // hex_val = 0xdeadbeef
+StrReadFmt("0xdeadbeef", "{}", hex_val);  // hex_val = 0xdeadbeef
 
 // Reading binary (auto-detected with 0b prefix)
 i8 bin_val = 0;
-StrReadFmt("0b101010", "{}", FMT(bin_val));  // bin_val = 42
+StrReadFmt("0b101010", "{}", bin_val);  // bin_val = 42
 
 // Reading octal (auto-detected with 0o prefix)
 i32 oct_val = 0;
-StrReadFmt("0o755", "{}", FMT(oct_val));  // oct_val = 493
+StrReadFmt("0o755", "{}", oct_val);  // oct_val = 493
 
 // Reading floating point
 f64 value = 0.0;
-StrReadFmt("3.14159", "{}", FMT(value));  // value = 3.14159
+StrReadFmt("3.14159", "{}", value);  // value = 3.14159
 
 // Reading scientific notation
-StrReadFmt("1.23e4", "{}", FMT(value));  // value = 12300.0
+StrReadFmt("1.23e4", "{}", value);  // value = 12300.0
 
 // Reading strings
 Str name = StrInit();
-StrReadFmt("Alice", "{}", FMT(name));  // name = "Alice"
+StrReadFmt("Alice", "{}", name);  // name = "Alice"
 
 // Reading quoted strings
-StrReadFmt("\"Hello, World!\"", "{}", FMT(name));  // name = "Hello, World!"
+StrReadFmt("\"Hello, World!\"", "{}", name);  // name = "Hello, World!"
 
 // Reading multiple values
 i32 count = 0;
 Str user = StrInit();
-StrReadFmt("Count: 42, Name: Alice", "Count: {}, Name: {}", FMT(count), FMT(user));
+StrReadFmt("Count: 42, Name: Alice", "Count: {}, Name: {}", count, user);
 // count = 42, user = "Alice"
 ```
 

--- a/Source/Misra/Parsers/JSON.c
+++ b/Source/Misra/Parsers/JSON.c
@@ -66,7 +66,7 @@ static StrIter JSkipObject(StrIter si) {
             return saved_si;
         }
 
-        LOG_INFO("User skipped reading of '{}' field in JSON object.", FMT(key));
+        LOG_INFO("User skipped reading of '{}' field in JSON object.", key);
 
         StrDeinit(&key);
         si = read_si;
@@ -78,7 +78,7 @@ static StrIter JSkipObject(StrIter si) {
 
     char c = StrIterPeek(&si);
     if (c != '}') {
-        LOG_ERROR("Expected end of object '}' but found '{c}'", FMT(c));
+        LOG_ERROR("Expected end of object '}' but found '{c}'", c);
         return saved_si;
     }
 
@@ -247,7 +247,7 @@ StrIter JReadString(StrIter si, Str* str) {
                         case 'u' :
                             LOG_ERROR(
                                 "No unicode support '{.6}'. Unicode sequence will be skipped.",
-                                FMT(LVAL(si.data + si.pos - 1))
+                                LVAL(si.data + si.pos - 1)
                             );
                             StrIterMove(&si, 5);
                             break;
@@ -367,7 +367,7 @@ StrIter JReadNumber(StrIter si, Number* num) {
     }
 
     if (!ns.length) {
-        LOG_ERROR("Failed to parse number. '{.8}'", FMT(LVAL(saved_si.data + saved_si.pos)));
+        LOG_ERROR("Failed to parse number. '{.8}'", LVAL(saved_si.data + saved_si.pos));
         StrDeinit(&ns);
         return saved_si;
     }

--- a/Source/Misra/Std/Container/BitVec.c
+++ b/Source/Misra/Std/Container/BitVec.c
@@ -186,7 +186,7 @@ BitVec BitVecClone(BitVec *bv) {
 bool BitVecGet(BitVec *bitvec, u64 idx) {
     ValidateBitVec(bitvec);
     if (idx >= bitvec->length) {
-        LOG_FATAL("Index {} exceeds bitvector length {}", FMT(idx), FMT(bitvec->length));
+        LOG_FATAL("Index {} exceeds bitvector length {}", idx, bitvec->length);
     }
     u64 byte_idx   = BIT_INDEX(idx);
     u64 bit_offset = BIT_OFFSET(idx);
@@ -197,7 +197,7 @@ bool BitVecGet(BitVec *bitvec, u64 idx) {
 void BitVecSet(BitVec *bitvec, u64 idx, bool value) {
     ValidateBitVec(bitvec);
     if (idx >= bitvec->length) {
-        LOG_FATAL("Index {} exceeds bitvector length {}", FMT(idx), FMT(bitvec->length));
+        LOG_FATAL("Index {} exceeds bitvector length {}", idx, bitvec->length);
     }
     u64 byte_idx   = BIT_INDEX(idx);
     u64 bit_offset = BIT_OFFSET(idx);
@@ -212,7 +212,7 @@ void BitVecSet(BitVec *bitvec, u64 idx, bool value) {
 void BitVecFlip(BitVec *bitvec, u64 idx) {
     ValidateBitVec(bitvec);
     if (idx >= bitvec->length) {
-        LOG_FATAL("Index {} exceeds bitvector length {}", FMT(idx), FMT(bitvec->length));
+        LOG_FATAL("Index {} exceeds bitvector length {}", idx, bitvec->length);
     }
     u64 byte_idx   = BIT_INDEX(idx);
     u64 bit_offset = BIT_OFFSET(idx);
@@ -244,7 +244,7 @@ bool BitVecPop(BitVec *bitvec) {
 void BitVecInsert(BitVec *bitvec, u64 idx, bool value) {
     ValidateBitVec(bitvec);
     if (idx > bitvec->length) {
-        LOG_FATAL("Index {} exceeds bitvector length {}", FMT(idx), FMT(bitvec->length));
+        LOG_FATAL("Index {} exceeds bitvector length {}", idx, bitvec->length);
     }
     // For now, implement as push + manual bit shifting (simple but not efficient)
     BitVecPush(bitvec, false);
@@ -261,7 +261,7 @@ void BitVecInsert(BitVec *bitvec, u64 idx, bool value) {
 void BitVecInsertRange(BitVec *bv, u64 idx, u64 count, bool value) {
     ValidateBitVec(bv);
     if (idx > bv->length) {
-        LOG_FATAL("Index {} exceeds bitvector length {}", FMT(idx), FMT(bv->length));
+        LOG_FATAL("Index {} exceeds bitvector length {}", idx, bv->length);
     }
     if (count == 0) {
         return;
@@ -288,7 +288,7 @@ void BitVecInsertMultiple(BitVec *bv, u64 idx, BitVec *other) {
     ValidateBitVec(bv);
     ValidateBitVec(other);
     if (idx > bv->length) {
-        LOG_FATAL("Index {} exceeds bitvector length {}", FMT(idx), FMT(bv->length));
+        LOG_FATAL("Index {} exceeds bitvector length {}", idx, bv->length);
     }
     if (other->length == 0) {
         return;
@@ -315,7 +315,7 @@ void BitVecInsertMultiple(BitVec *bv, u64 idx, BitVec *other) {
 void BitVecInsertPattern(BitVec *bv, u64 idx, u8 pattern, u64 pattern_bits) {
     ValidateBitVec(bv);
     if (idx > bv->length) {
-        LOG_FATAL("Index {} exceeds bitvector length {}", FMT(idx), FMT(bv->length));
+        LOG_FATAL("Index {} exceeds bitvector length {}", idx, bv->length);
     }
     if (pattern_bits == 0 || pattern_bits > 8) {
         return;
@@ -342,7 +342,7 @@ void BitVecInsertPattern(BitVec *bv, u64 idx, u8 pattern, u64 pattern_bits) {
 bool BitVecRemove(BitVec *bv, u64 idx) {
     ValidateBitVec(bv);
     if (idx >= bv->length) {
-        LOG_FATAL("Index {} exceeds bitvector length {}", FMT(idx), FMT(bv->length));
+        LOG_FATAL("Index {} exceeds bitvector length {}", idx, bv->length);
     }
 
     // Get the bit value before removing it
@@ -361,7 +361,7 @@ bool BitVecRemove(BitVec *bv, u64 idx) {
 void BitVecRemoveRange(BitVec *bv, u64 idx, u64 count) {
     ValidateBitVec(bv);
     if (idx >= bv->length) {
-        LOG_FATAL("Index {} exceeds bitvector length {}", FMT(idx), FMT(bv->length));
+        LOG_FATAL("Index {} exceeds bitvector length {}", idx, bv->length);
     }
     if (count == 0) {
         return;
@@ -527,17 +527,17 @@ bool BitVecEqualsRange(BitVec *bv1, u64 start1, BitVec *bv2, u64 start2, u64 len
     if (start1 + len > bv1->length) {
         LOG_FATAL(
             "Range [{}:{}] exceeds bitvector1 length {}",
-            FMT(start1),
-            FMT(LVAL(start1 + len - 1)),
-            FMT(bv1->length)
+            start1,
+            LVAL(start1 + len - 1),
+            bv1->length
         );
     }
     if (start2 + len > bv2->length) {
         LOG_FATAL(
             "Range [{}:{}] exceeds bitvector2 length {}",
-            FMT(start2),
-            FMT(LVAL(start2 + len - 1)),
-            FMT(bv2->length)
+            start2,
+            LVAL(start2 + len - 1),
+            bv2->length
         );
     }
 
@@ -579,17 +579,17 @@ int BitVecCompareRange(BitVec *bv1, u64 start1, BitVec *bv2, u64 start2, u64 len
     if (start1 + len > bv1->length) {
         LOG_FATAL(
             "Range [{}:{}] exceeds bitvector1 length {}",
-            FMT(start1),
-            FMT(LVAL(start1 + len - 1)),
-            FMT(bv1->length)
+            start1,
+            LVAL(start1 + len - 1),
+            bv1->length
         );
     }
     if (start2 + len > bv2->length) {
         LOG_FATAL(
             "Range [{}:{}] exceeds bitvector2 length {}",
-            FMT(start2),
-            FMT(LVAL(start2 + len - 1)),
-            FMT(bv2->length)
+            start2,
+            LVAL(start2 + len - 1),
+            bv2->length
         );
     }
 

--- a/Source/Misra/Std/Container/BitVec.c
+++ b/Source/Misra/Std/Container/BitVec.c
@@ -525,20 +525,10 @@ bool BitVecEqualsRange(BitVec *bv1, u64 start1, BitVec *bv2, u64 start2, u64 len
     ValidateBitVec(bv2);
 
     if (start1 + len > bv1->length) {
-        LOG_FATAL(
-            "Range [{}:{}] exceeds bitvector1 length {}",
-            start1,
-            LVAL(start1 + len - 1),
-            bv1->length
-        );
+        LOG_FATAL("Range [{}:{}] exceeds bitvector1 length {}", start1, LVAL(start1 + len - 1), bv1->length);
     }
     if (start2 + len > bv2->length) {
-        LOG_FATAL(
-            "Range [{}:{}] exceeds bitvector2 length {}",
-            start2,
-            LVAL(start2 + len - 1),
-            bv2->length
-        );
+        LOG_FATAL("Range [{}:{}] exceeds bitvector2 length {}", start2, LVAL(start2 + len - 1), bv2->length);
     }
 
     for (u64 i = 0; i < len; i++) {
@@ -577,20 +567,10 @@ int BitVecCompareRange(BitVec *bv1, u64 start1, BitVec *bv2, u64 start2, u64 len
     ValidateBitVec(bv2);
 
     if (start1 + len > bv1->length) {
-        LOG_FATAL(
-            "Range [{}:{}] exceeds bitvector1 length {}",
-            start1,
-            LVAL(start1 + len - 1),
-            bv1->length
-        );
+        LOG_FATAL("Range [{}:{}] exceeds bitvector1 length {}", start1, LVAL(start1 + len - 1), bv1->length);
     }
     if (start2 + len > bv2->length) {
-        LOG_FATAL(
-            "Range [{}:{}] exceeds bitvector2 length {}",
-            start2,
-            LVAL(start2 + len - 1),
-            bv2->length
-        );
+        LOG_FATAL("Range [{}:{}] exceeds bitvector2 length {}", start2, LVAL(start2 + len - 1), bv2->length);
     }
 
     // Compare bit by bit in the specified range

--- a/Source/Misra/Std/Container/Str.c
+++ b/Source/Misra/Std/Container/Str.c
@@ -333,7 +333,7 @@ Str* StrFromU64(Str* str, u64 value, const StrIntFormat* config) {
     }
 
     if (!is_valid_base(config->base)) {
-        LOG_ERROR("Invalid base: {}", FMT(config->base));
+        LOG_ERROR("Invalid base: {}", config->base);
         return NULL;
     }
 
@@ -380,7 +380,7 @@ Str* StrFromI64(Str* str, i64 value, const StrIntFormat* config) {
     }
 
     if (!is_valid_base(config->base)) {
-        LOG_ERROR("Invalid base: {}", FMT(config->base));
+        LOG_ERROR("Invalid base: {}", config->base);
         return NULL;
     }
 
@@ -414,7 +414,7 @@ Str* StrFromF64(Str* str, f64 value, const StrFloatFormat* config) {
     }
 
     if (config->precision > 17) {
-        LOG_ERROR("Precision {} exceeds maximum (17)", FMT(config->precision));
+        LOG_ERROR("Precision {} exceeds maximum (17)", config->precision);
         return NULL;
     }
 
@@ -578,7 +578,7 @@ bool StrToU64(const Str* str, u64* value, const StrParseConfig* config) {
 
     u8 base = config->base;
     if (base != 0 && !is_valid_base(base)) {
-        LOG_ERROR("Invalid base: {}", FMT(base));
+        LOG_ERROR("Invalid base: {}", base);
         return false;
     }
 
@@ -621,7 +621,7 @@ bool StrToU64(const Str* str, u64* value, const StrParseConfig* config) {
         if (!char_to_digit(str->data[pos], &digit, base)) {
             if (IS_SPACE(str->data[pos]))
                 break;
-            LOG_ERROR("Invalid digit for base {}: {c}", FMT(base), FMT(str->data[pos]));
+            LOG_ERROR("Invalid digit for base {}: {c}", base, str->data[pos]);
             return false;
         }
 

--- a/Source/Misra/Std/Container/Vec.c
+++ b/Source/Misra/Std/Container/Vec.c
@@ -90,7 +90,7 @@ void reserve_vec(GenericVec *vec, size item_size, size n) {
             Str syserr;
             StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
                 SysStrError(errno, &syserr);
-                LOG_FATAL("realloc() failed : {}", FMT(syserr));
+                LOG_FATAL("realloc() failed : {}", syserr);
             });
         }
         // it's mandatory to set the pointer here, because next call to any vec_ will do a validation check
@@ -139,7 +139,7 @@ void reduce_space_vec(GenericVec *vec, size item_size) {
             Str syserr;
             StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
                 SysStrError(errno, &syserr);
-                LOG_FATAL("realloc() failed : {}", FMT(syserr));
+                LOG_FATAL("realloc() failed : {}", syserr);
             });
         }
         vec->capacity = vec->length;

--- a/Source/Misra/Std/File.c
+++ b/Source/Misra/Std/File.c
@@ -34,7 +34,7 @@ bool ReadCompleteFile(const char *filename, char **data, size *file_size, size *
             Str syserr;
             StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
                 SysStrError(errno, &syserr);
-                LOG_FATAL("malloc() failed : {}", FMT(syserr));
+                LOG_FATAL("malloc() failed : {}", syserr);
             });
         }
 
@@ -58,7 +58,7 @@ bool ReadCompleteFile(const char *filename, char **data, size *file_size, size *
         Str syserr = StrInit();
         StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
             SysStrError(e, &syserr);
-            LOG_ERROR("fopen() failed : {}", FMT(syserr));
+            LOG_ERROR("fopen() failed : {}", syserr);
         });
 
         return false;
@@ -70,7 +70,7 @@ bool ReadCompleteFile(const char *filename, char **data, size *file_size, size *
         Str syserr = StrInit();
         StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
             SysStrError(errno, &syserr);
-            LOG_ERROR("failed to read complete file. : {}", FMT(syserr));
+            LOG_ERROR("failed to read complete file. : {}", syserr);
         });
 
         return false;

--- a/Source/Misra/Std/Io.c
+++ b/Source/Misra/Std/Io.c
@@ -550,7 +550,7 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
 
             // Check if reading failed
             if (!next || next == in) {
-                LOG_ERROR("Failed to read value for placeholder {}", FMT(LVAL(arg_index - 1)));
+                LOG_ERROR("Failed to read value for placeholder {}", LVAL(arg_index - 1));
                 return NULL;
             }
 
@@ -565,8 +565,8 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
             if (!in || *in != *p) {
                 LOG_ERROR(
                     "Input '{.8}' does not match format string '{.8}'",
-                    FMT(LVAL(in ? in : "(null)")),
-                    FMT(LVAL(p ? p : "(null)"))
+                    LVAL(in ? in : "(null)"),
+                    LVAL(p ? p : "(null)")
                 );
                 return NULL;
             }
@@ -617,7 +617,7 @@ void FReadFmtInternal(FILE* file, const char* fmtstr, TypeSpecificIO* argv, size
         } else {
             Str err = StrInit();
             SysStrError(errno, &err);
-            LOG_ERROR("Could not save file position for rollback: {}", FMT(err));
+            LOG_ERROR("Could not save file position for rollback: {}", err);
             StrDeinit(&err);
         }
     }
@@ -1240,7 +1240,7 @@ static char ProcessEscape(const char** str) {
             break;
         }
         default :
-            LOG_ERROR("Invalid escape sequence '\\{c}'", FMT(s[0]));
+            LOG_ERROR("Invalid escape sequence '\\{c}'", s[0]);
             return 0;
     }
 
@@ -1681,7 +1681,7 @@ const char* _read_u8(const char* i, FmtInfo* fmt_info, u8* v) {
 
     // Check for overflow
     if (val > UINT8_MAX) {
-        LOG_ERROR("Value {} exceeds u8 maximum ({})", FMT(val), FMT(LVAL(UINT8_MAX)));
+        LOG_ERROR("Value {} exceeds u8 maximum ({})", val, UINT8_MAX);
         StrDeinit(&temp);
         return start;
     }
@@ -1756,7 +1756,7 @@ const char* _read_u16(const char* i, FmtInfo* fmt_info, u16* v) {
 
     // Check for overflow
     if (val > UINT16_MAX) {
-        LOG_ERROR("Value {} exceeds u16 maximum ({})", FMT(val), FMT(LVAL(UINT16_MAX)));
+        LOG_ERROR("Value {} exceeds u16 maximum ({})", val, UINT16_MAX);
         StrDeinit(&temp);
         return start;
     }
@@ -1830,7 +1830,7 @@ const char* _read_u32(const char* i, FmtInfo* fmt_info, u32* v) {
 
     // Check for overflow
     if (val > UINT32_MAX) {
-        LOG_ERROR("Valuei {} exceeds u32 maximum ({})", FMT(val), FMT(LVAL(UINT32_MAX)));
+        LOG_ERROR("Value {} exceeds u32 maximum ({})", val, UINT32_MAX);
         StrDeinit(&temp);
         return start;
     }
@@ -1970,7 +1970,7 @@ const char* _read_i8(const char* i, FmtInfo* fmt_info, i8* v) {
 
     // Check for overflow/underflow
     if (val > INT8_MAX || val < INT8_MIN) {
-        LOG_ERROR("Value {} outside i8 range ({} to {})", FMT(val), FMT(LVAL(INT8_MIN)), FMT(LVAL(INT8_MAX)));
+        LOG_ERROR("Value {} outside i8 range ({} to {})", val, INT8_MIN, INT8_MAX);
         StrDeinit(&temp);
         return start;
     }
@@ -2045,7 +2045,7 @@ const char* _read_i16(const char* i, FmtInfo* fmt_info, i16* v) {
 
     // Check for overflow/underflow
     if (val > INT16_MAX || val < INT16_MIN) {
-        LOG_ERROR("Value {} outside i16 range ({} to {})", FMT(val), FMT(LVAL(INT16_MIN)), FMT(LVAL(INT16_MAX)));
+        LOG_ERROR("Value {} outside i16 range ({} to {})", val, INT16_MIN, INT16_MAX);
         StrDeinit(&temp);
         return start;
     }
@@ -2120,7 +2120,7 @@ const char* _read_i32(const char* i, FmtInfo* fmt_info, i32* v) {
 
     // Check for overflow/underflow
     if (val > INT32_MAX || val < INT32_MIN) {
-        LOG_ERROR("Value {} outside i32 range ({} to {})", FMT(val), FMT(LVAL(INT32_MIN)), FMT(LVAL(INT32_MAX)));
+        LOG_ERROR("Value {} outside i32 range ({} to {})", val, INT32_MIN, INT32_MAX);
         StrDeinit(&temp);
         return start;
     }

--- a/Source/Misra/Std/Log.c
+++ b/Source/Misra/Std/Log.c
@@ -32,7 +32,7 @@ void LogInit(bool redirect) {
             Str syserr;
             StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
                 SysStrError(errno, &syserr);
-                LOG_ERROR("Failed to get localtime : {}", FMT(syserr));
+                LOG_ERROR("Failed to get localtime : {}", syserr);
             });
             goto LOG_STREAM_FALLBACK;
         }
@@ -79,7 +79,7 @@ void LogInit(bool redirect) {
             Str syserr;
             StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
                 SysStrError(e, &syserr);
-                LOG_ERROR("Failed to open log file : {}", FMT(syserr));
+                LOG_ERROR("Failed to open log file : {}", syserr);
             });
             goto LOG_STREAM_FALLBACK;
         }

--- a/Source/Misra/Sys.c
+++ b/Source/Misra/Sys.c
@@ -161,7 +161,7 @@ SysDirContents SysGetDirContents(const char* path) {
         Str err;
         StrInitStack(err, SYS_ERROR_STR_MAX_LENGTH, {
             SysStrError(errno, &err);
-            LOG_ERROR("opendir(\"{}\") failed : {}", FMT(path), FMT(err));
+            LOG_ERROR("opendir(\"{}\") failed : {}", path, err);
         });
         return (SysDirContents) {0};
     }
@@ -186,7 +186,7 @@ SysDirContents SysGetDirContents(const char* path) {
         } else {
             Str         entry_path = StrInit();
             const char* dir_name   = &entry->d_name[0];
-            StrWriteFmt(&entry_path, "{}/{}", FMT(path), FMT(dir_name));
+            StrWriteFmt(&entry_path, "{}/{}", path, dir_name);
 
             struct stat path_stat;
             stat(entry_path.data, &path_stat);
@@ -232,7 +232,7 @@ i64 SysGetFileSize(const char* filename) {
         Str err;
         StrInitStack(err, SYS_ERROR_STR_MAX_LENGTH, {
             SysStrError(errno, &err);
-            LOG_ERROR("failed to open file: {}\n", FMT(err));
+            LOG_ERROR("failed to open file: {}\n", err);
         });
         return -1;
     }
@@ -242,7 +242,7 @@ i64 SysGetFileSize(const char* filename) {
         Str err;
         StrInitStack(err, SYS_ERROR_STR_MAX_LENGTH, {
             SysStrError(errno, &err);
-            LOG_ERROR("failed to get file size: {}\n", FMT(err));
+            LOG_ERROR("failed to get file size: {}\n", err);
         });
         CloseHandle(file);
         return -1;
@@ -259,7 +259,7 @@ i64 SysGetFileSize(const char* filename) {
         Str err;
         StrInitStack(err, SYS_ERROR_STR_MAX_LENGTH, {
             SysStrError(errno, &err);
-            LOG_ERROR("failed to get file size: {}\n", FMT(err));
+            LOG_ERROR("failed to get file size: {}\n", err);
         });
         return -1;
     }
@@ -598,7 +598,7 @@ SysProcInfo* SysCreateProcess(const char* executable, Strs* argv, Strs* env) {
 
     if (!success) {
         DWORD error = GetLastError();
-        LOG_ERROR("CreateProcess failed with error {}", FMT(error));
+        LOG_ERROR("CreateProcess failed with error {}", error);
         FREE(proc_info);
         return NULL;
     }

--- a/Tests/Json/Write.Nested.c
+++ b/Tests/Json/Write.Nested.c
@@ -244,13 +244,13 @@ bool test_complex_api_response_writing(void) {
             // Write dynamic key for source function ID
             Str source_key = StrInit();
             u64 source_id  = response.data.length > 0 ? VecAt(&response.data, 0).source_function_id : 0;
-            StrWriteFmt(&source_key, "{}", FMT(source_id));
+            StrWriteFmt(&source_key, "{}", source_id);
 
             JW_OBJ_KV(json, source_key.data, {
                 if (response.data.length > 0) {
                     AnnSymbol* s          = &VecAt(&response.data, 0);
                     Str        target_key = StrInit();
-                    StrWriteFmt(&target_key, "{}", FMT(s->target_function_id));
+                    StrWriteFmt(&target_key, "{}", s->target_function_id);
 
                     JW_OBJ_KV(json, target_key.data, {
                         JW_FLT_KV(json, "distance", s->distance);

--- a/Tests/Json/Write.Nested.c
+++ b/Tests/Json/Write.Nested.c
@@ -407,11 +407,11 @@ bool test_dynamic_object_keys_writing(void) {
         JW_OBJ_KV(json, "functions", {
             VecForeach(&symbols, symbol, {
                 Str source_key = StrInit();
-                StrWriteFmt(&source_key, "{}", FMT(symbol.source_function_id));
+                StrWriteFmt(&source_key, "{}", symbol.source_function_id);
 
                 JW_OBJ_KV(json, source_key.data, {
                     Str target_key = StrInit();
-                    StrWriteFmt(&target_key, "{}", FMT(symbol.target_function_id));
+                    StrWriteFmt(&target_key, "{}", symbol.target_function_id);
 
                     JW_OBJ_KV(json, target_key.data, {
                         JW_FLT_KV(json, "distance", symbol.distance);

--- a/Tests/Std/Io.Read.c
+++ b/Tests/Std/Io.Read.c
@@ -47,75 +47,75 @@ bool test_integer_decimal_reading(void) {
 
     // Test signed integers
     i8 i8_val = 0;
-    StrReadFmt("-42", "{}", FMT(i8_val));
+    StrReadFmt("-42", "{}", i8_val);
     success = success && (i8_val == -42);
 
     i16 i16_val = 0;
-    StrReadFmt("-1234", "{}", FMT(i16_val));
+    StrReadFmt("-1234", "{}", i16_val);
     success = success && (i16_val == -1234);
 
     i32 i32_val = 0;
-    StrReadFmt("-123456", "{}", FMT(i32_val));
+    StrReadFmt("-123456", "{}", i32_val);
     success = success && (i32_val == -123456);
 
     i64 i64_val = 0;
-    StrReadFmt("-1234567890", "{}", FMT(i64_val));
+    StrReadFmt("-1234567890", "{}", i64_val);
     success = success && (i64_val == -1234567890LL);
 
     // Test unsigned integers
     u8 u8_val = 0;
-    StrReadFmt("42", "{}", FMT(u8_val));
+    StrReadFmt("42", "{}", u8_val);
     success = success && (u8_val == 42);
 
     u16 u16_val = 0;
-    StrReadFmt("1234", "{}", FMT(u16_val));
+    StrReadFmt("1234", "{}", u16_val);
     success = success && (u16_val == 1234);
 
     u32 u32_val = 0;
-    StrReadFmt("123456", "{}", FMT(u32_val));
+    StrReadFmt("123456", "{}", u32_val);
     success = success && (u32_val == 123456);
 
     u64 u64_val = 0;
-    StrReadFmt("1234567890", "{}", FMT(u64_val));
+    StrReadFmt("1234567890", "{}", u64_val);
     success = success && (u64_val == 1234567890ULL);
 
     // Test edge cases
     i8_val = 0;
-    StrReadFmt("127", "{}", FMT(i8_val));
+    StrReadFmt("127", "{}", i8_val);
     success = success && (i8_val == 127);
 
     i8_val = 0;
-    StrReadFmt("-128", "{}", FMT(i8_val));
+    StrReadFmt("-128", "{}", i8_val);
     success = success && (i8_val == -128);
 
     u8_val = 0;
-    StrReadFmt("255", "{}", FMT(u8_val));
+    StrReadFmt("255", "{}", u8_val);
     success = success && (u8_val == 255);
 
     u8_val = 0;
-    StrReadFmt("0", "{}", FMT(u8_val));
+    StrReadFmt("0", "{}", u8_val);
     success = success && (u8_val == 0);
 
     // Test leading zeros
     i32_val = 0;
-    StrReadFmt("000042", "{}", FMT(i32_val));
+    StrReadFmt("000042", "{}", i32_val);
     success = success && (i32_val == 42);
 
     i32_val = 0;
-    StrReadFmt("-000042", "{}", FMT(i32_val));
+    StrReadFmt("-000042", "{}", i32_val);
     success = success && (i32_val == -42);
 
     // Test whitespace handling
     i32_val = 0;
-    StrReadFmt("   42", "{}", FMT(i32_val));
+    StrReadFmt("   42", "{}", i32_val);
     success = success && (i32_val == 42);
 
     i32_val = 0;
-    StrReadFmt("42   ", "{}", FMT(i32_val));
+    StrReadFmt("42   ", "{}", i32_val);
     success = success && (i32_val == 42);
 
     i32_val = 0;
-    StrReadFmt("  42  ", "{}", FMT(i32_val));
+    StrReadFmt("  42  ", "{}", i32_val);
     success = success && (i32_val == 42);
 
     return success;
@@ -128,24 +128,24 @@ bool test_integer_hex_reading(void) {
     bool success = true;
 
     u32 val = 0;
-    StrReadFmt("0xdeadbeef", "{}", FMT(val));
+    StrReadFmt("0xdeadbeef", "{}", val);
     success = success && (val == 0xdeadbeef);
 
     val = 0;
-    StrReadFmt("0xDEADBEEF", "{}", FMT(val));
+    StrReadFmt("0xDEADBEEF", "{}", val);
     success = success && (val == 0xDEADBEEF);
 
     // Test hex edge cases
     val = 0;
-    StrReadFmt("0x0", "{}", FMT(val));
+    StrReadFmt("0x0", "{}", val);
     success = success && (val == 0);
 
     val = 0;
-    StrReadFmt("0xf", "{}", FMT(val));
+    StrReadFmt("0xf", "{}", val);
     success = success && (val == 0xf);
 
     val = 0;
-    StrReadFmt("0xaBcDeF", "{}", FMT(val));
+    StrReadFmt("0xaBcDeF", "{}", val);
     success = success && (val == 0xabcdef);
 
     return success;
@@ -158,16 +158,16 @@ bool test_integer_binary_reading(void) {
     bool success = true;
 
     i8 val = 0;
-    StrReadFmt("0b101010", "{}", FMT(val));
+    StrReadFmt("0b101010", "{}", val);
     success = success && (val == 42);
 
     // Test binary edge cases
     val = 0;
-    StrReadFmt("0b0", "{}", FMT(val));
+    StrReadFmt("0b0", "{}", val);
     success = success && (val == 0);
 
     val = 0;
-    StrReadFmt("0b1", "{}", FMT(val));
+    StrReadFmt("0b1", "{}", val);
     success = success && (val == 1);
 
     return success;
@@ -180,20 +180,20 @@ bool test_integer_octal_reading(void) {
     bool success = true;
 
     i32 val = 0;
-    StrReadFmt("0o755", "{}", FMT(val));
+    StrReadFmt("0o755", "{}", val);
     success = success && (val == 0755);
 
     val = 0;
-    StrReadFmt("755", "{}", FMT(val));
+    StrReadFmt("755", "{}", val);
     success = success && (val == 755);
 
     // Test octal edge cases
     val = 0;
-    StrReadFmt("0o0", "{}", FMT(val));
+    StrReadFmt("0o0", "{}", val);
     success = success && (val == 0);
 
     val = 0;
-    StrReadFmt("0o7", "{}", FMT(val));
+    StrReadFmt("0o7", "{}", val);
     success = success && (val == 7);
 
     return success;
@@ -207,30 +207,30 @@ bool test_float_basic_reading(void) {
 
     // Test basic float values
     f32 f32_val = 0.0f;
-    StrReadFmt("3.14159", "{}", FMT(f32_val));
+    StrReadFmt("3.14159", "{}", f32_val);
     success = success && float_equals(f32_val, 3.14159f);
 
     f64 f64_val = 0.0;
-    StrReadFmt("3.14159265359", "{}", FMT(f64_val));
+    StrReadFmt("3.14159265359", "{}", f64_val);
     success = success && double_equals(f64_val, 3.14159265359);
 
     // Test float edge cases
     f64_val = 1.0;
-    StrReadFmt("0.0", "{}", FMT(f64_val));
+    StrReadFmt("0.0", "{}", f64_val);
     success = success && double_equals(f64_val, 0.0);
 
     f64_val = 1.0;
-    StrReadFmt("-0.0", "{}", FMT(f64_val));
+    StrReadFmt("-0.0", "{}", f64_val);
     // Special case for -0.0 which compares equal to 0.0 but has different bit pattern
     // We'll just check if it's close to zero
     success = success && double_equals(f64_val, 0.0);
 
     f64_val = 0.0;
-    StrReadFmt("42.0", "{}", FMT(f64_val));
+    StrReadFmt("42.0", "{}", f64_val);
     success = success && double_equals(f64_val, 42.0);
 
     f64_val = 0.0;
-    StrReadFmt("0.42", "{}", FMT(f64_val));
+    StrReadFmt("0.42", "{}", f64_val);
     success = success && double_equals(f64_val, 0.42);
 
     return success;
@@ -243,32 +243,32 @@ bool test_float_scientific_reading(void) {
     bool success = true;
 
     f64 val = 0.0;
-    StrReadFmt("1.23e4", "{}", FMT(val));
+    StrReadFmt("1.23e4", "{}", val);
     success = success && double_equals(val, 12300.0);
 
     val = 0.0;
-    StrReadFmt("1.23E4", "{}", FMT(val));
+    StrReadFmt("1.23E4", "{}", val);
     success = success && double_equals(val, 12300.0);
 
     val = 0.0;
-    StrReadFmt("1.23e+4", "{}", FMT(val));
+    StrReadFmt("1.23e+4", "{}", val);
     success = success && double_equals(val, 12300.0);
 
     val = 0.0;
-    StrReadFmt("1.23e-4", "{}", FMT(val));
+    StrReadFmt("1.23e-4", "{}", val);
     success = success && double_equals(val, 0.000123);
 
     // Test scientific notation edge cases
     val = 0.0;
-    StrReadFmt("1.0e0", "{}", FMT(val));
+    StrReadFmt("1.0e0", "{}", val);
     success = success && double_equals(val, 1.0);
 
     val = 0.0;
-    StrReadFmt("1.0E-0", "{}", FMT(val));
+    StrReadFmt("1.0E-0", "{}", val);
     success = success && double_equals(val, 1.0);
 
     val = 0.0;
-    StrReadFmt("1.0e+0", "{}", FMT(val));
+    StrReadFmt("1.0e+0", "{}", val);
     success = success && double_equals(val, 1.0);
 
     return success;
@@ -282,7 +282,7 @@ bool test_string_reading(void) {
 
     // Test basic string reading
     Str s = StrInit();
-    StrReadFmt("Hello", "{}", FMT(s));
+    StrReadFmt("Hello", "{}", s);
 
     Str expected = StrInitFromZstr("Hello");
     success      = success && (StrCmp(&s, &expected) == 0);
@@ -290,7 +290,7 @@ bool test_string_reading(void) {
     StrClear(&s);
 
     // Test quoted string reading
-    StrReadFmt("\"Hello, World!\"", "{}", FMT(s));
+    StrReadFmt("\"Hello, World!\"", "{}", s);
 
     expected = StrInitFromZstr("Hello, World!");
     success  = success && (StrCmp(&s, &expected) == 0);
@@ -309,7 +309,7 @@ bool test_multiple_arguments_reading(void) {
 
     i32 num  = 0;
     Str name = StrInit();
-    StrReadFmt("Count: 42, Name: Alice", "Count: {}, Name: {}", FMT(num), FMT(name));
+    StrReadFmt("Count: 42, Name: Alice", "Count: {}, Name: {}", num, name);
 
     success = success && (num == 42);
 
@@ -320,7 +320,7 @@ bool test_multiple_arguments_reading(void) {
 
     // Test with different order
     f64 val = 0.0;
-    StrReadFmt("Value: 3.14, Name: Bob", "Value: {}, Name: {}", FMT(val), FMT(name));
+    StrReadFmt("Value: 3.14, Name: Bob", "Value: {}, Name: {}", val, name);
 
     success = success && double_equals(val, 3.14);
 
@@ -344,18 +344,18 @@ bool test_error_handling_reading(void) {
 
     // Test mismatched format
     i32 num = 42;
-    StrReadFmt("Count: forty-two", "Count: {}", FMT(num));
+    StrReadFmt("Count: forty-two", "Count: {}", num);
     // The value should remain unchanged since the parsing should fail
     success = success && (num == 42);
 
     // Test invalid integer
     num = 42;
-    StrReadFmt("Count: abc", "Count: {}", FMT(num));
+    StrReadFmt("Count: abc", "Count: {}", num);
     success = success && (num == 42);
 
     // Test overflow
     i8 small = 42;
-    StrReadFmt("Value: 1000", "Value: {}", FMT(small));
+    StrReadFmt("Value: 1000", "Value: {}", small);
     success = success && (small == 42);
 
     return success;
@@ -369,56 +369,56 @@ bool test_character_ordinal_reading(void) {
 
     // Test reading single character into u8
     u8 u8_val = 0;
-    StrReadFmt("A", "{c}", FMT(u8_val));
+    StrReadFmt("A", "{c}", u8_val);
     printf("u8_val = %d, expected = %d, pass = %s\n", u8_val, 'A', (u8_val == 'A') ? "true" : "false");
     success = success && (u8_val == 'A');
 
     u8_val = 0;
-    StrReadFmt("z", "{c}", FMT(u8_val));
+    StrReadFmt("z", "{c}", u8_val);
     printf("u8_val = %d, expected = %d, pass = %s\n", u8_val, 'z', (u8_val == 'z') ? "true" : "false");
     success = success && (u8_val == 'z');
 
     // Test reading single character into signed integers
     i8 i8_val = 0;
-    StrReadFmt("B", "{c}", FMT(i8_val));
+    StrReadFmt("B", "{c}", i8_val);
     printf("i8_val = %d, expected = %d, pass = %s\n", i8_val, 'B', (i8_val == 'B') ? "true" : "false");
     success = success && (i8_val == 'B');
 
     i16 i16_val = 0;
-    StrReadFmt("C", "{c}", FMT(i16_val));
+    StrReadFmt("C", "{c}", i16_val);
     printf("i16_val = %d, expected = %d, pass = %s\n", i16_val, 'C', (i16_val == 'C') ? "true" : "false");
     success = success && (i16_val == 'C');
 
     i32 i32_val = 0;
-    StrReadFmt("D", "{c}", FMT(i32_val));
+    StrReadFmt("D", "{c}", i32_val);
     printf("i32_val = %d, expected = %d, pass = %s\n", i32_val, 'D', (i32_val == 'D') ? "true" : "false");
     success = success && (i32_val == 'D');
 
     i64 i64_val = 0;
-    StrReadFmt("E", "{c}", FMT(i64_val));
+    StrReadFmt("E", "{c}", i64_val);
     printf("i64_val = %lld, expected = %d, pass = %s\n", i64_val, 'E', (i64_val == 'E') ? "true" : "false");
     success = success && (i64_val == 'E');
 
     // Test reading single character into unsigned integers
     u16 u16_val = 0;
-    StrReadFmt("F", "{c}", FMT(u16_val));
+    StrReadFmt("F", "{c}", u16_val);
     printf("u16_val = %d, expected = %d, pass = %s\n", u16_val, 'F', (u16_val == 'F') ? "true" : "false");
     success = success && (u16_val == 'F');
 
     u32 u32_val = 0;
-    StrReadFmt("G", "{c}", FMT(u32_val));
+    StrReadFmt("G", "{c}", u32_val);
     printf("u32_val = %d, expected = %d, pass = %s\n", u32_val, 'G', (u32_val == 'G') ? "true" : "false");
     success = success && (u32_val == 'G');
 
     u64 u64_val = 0;
-    StrReadFmt("H", "{c}", FMT(u64_val));
+    StrReadFmt("H", "{c}", u64_val);
     printf("u64_val = %llu, expected = %d, pass = %s\n", u64_val, 'H', (u64_val == 'H') ? "true" : "false");
     success = success && (u64_val == 'H');
 
     // Test reading multiple characters into larger integer types
     // For u16, read 2 characters
     u16_val = 0;
-    StrReadFmt("AB", "{c}", FMT(u16_val));
+    StrReadFmt("AB", "{c}", u16_val);
     bool u16_multi_pass = (ZstrCompareN((const char*)&u16_val, "AB", 2) == 0);
     printf("u16_val multi-char test: comparing memory with 'AB', pass = %s\n", u16_multi_pass ? "true" : "false");
     printf(
@@ -432,75 +432,75 @@ bool test_character_ordinal_reading(void) {
 
     // For i16, read 2 characters
     i16_val = 0;
-    StrReadFmt("CD", "{c}", FMT(i16_val));
+    StrReadFmt("CD", "{c}", i16_val);
     bool i16_multi_pass = (ZstrCompareN((const char*)&i16_val, "CD", 2) == 0);
     printf("i16_val multi-char test: comparing memory with 'CD', pass = %s\n", i16_multi_pass ? "true" : "false");
     success = success && i16_multi_pass;
 
     // For u32, read up to 4 characters
     u32_val = 0;
-    StrReadFmt("EFGH", "{c}", FMT(u32_val));
+    StrReadFmt("EFGH", "{c}", u32_val);
     bool u32_multi_pass = (ZstrCompareN((const char*)&u32_val, "EFGH", 4) == 0);
     printf("u32_val multi-char test: comparing memory with 'EFGH', pass = %s\n", u32_multi_pass ? "true" : "false");
     success = success && u32_multi_pass;
 
     // For i32, read up to 4 characters
     i32_val = 0;
-    StrReadFmt("IJKL", "{c}", FMT(i32_val));
+    StrReadFmt("IJKL", "{c}", i32_val);
     bool i32_multi_pass = (ZstrCompareN((const char*)&i32_val, "IJKL", 4) == 0);
     printf("i32_val multi-char test: comparing memory with 'IJKL', pass = %s\n", i32_multi_pass ? "true" : "false");
     success = success && i32_multi_pass;
 
     // For u64, read up to 8 characters
     u64_val = 0;
-    StrReadFmt("MNOPQRST", "{c}", FMT(u64_val));
+    StrReadFmt("MNOPQRST", "{c}", u64_val);
     bool u64_multi_pass = (ZstrCompareN((const char*)&u64_val, "MNOPQRST", 8) == 0);
     printf("u64_val multi-char test: comparing memory with 'MNOPQRST', pass = %s\n", u64_multi_pass ? "true" : "false");
     success = success && u64_multi_pass;
 
     // For i64, read up to 8 characters
     i64_val = 0;
-    StrReadFmt("UVWXYZab", "{c}", FMT(i64_val));
+    StrReadFmt("UVWXYZab", "{c}", i64_val);
     bool i64_multi_pass = (ZstrCompareN((const char*)&i64_val, "UVWXYZab", 8) == 0);
     printf("i64_val multi-char test: comparing memory with 'UVWXYZab', pass = %s\n", i64_multi_pass ? "true" : "false");
     success = success && i64_multi_pass;
 
     // Test reading characters into float types (should interpret as character ordinals)
     f32 f32_val = 0.0f;
-    StrReadFmt("A", "{c}", FMT(f32_val));
+    StrReadFmt("A", "{c}", f32_val);
     bool f32_pass = (f32_val == (f32)'A');
     printf("f32_val = %f, expected = %f, pass = %s\n", f32_val, (f32)'A', f32_pass ? "true" : "false");
     success = success && f32_pass;
 
     f64 f64_val = 0.0;
-    StrReadFmt("B", "{c}", FMT(f64_val));
+    StrReadFmt("B", "{c}", f64_val);
     bool f64_pass = (f64_val == (f64)'B');
     printf("f64_val = %f, expected = %f, pass = %s\n", f64_val, (f64)'B', f64_pass ? "true" : "false");
     success = success && f64_pass;
 
     // Test with high ASCII characters
     u8_val = 0;
-    StrReadFmt("~", "{c}", FMT(u8_val));
+    StrReadFmt("~", "{c}", u8_val);
     bool tilde_pass = (u8_val == '~');
     printf("u8_val = %d, expected = %d (~), pass = %s\n", u8_val, '~', tilde_pass ? "true" : "false");
     success = success && tilde_pass;
 
     // Test partial reads for larger types with fewer characters
     u32_val = 0;
-    StrReadFmt("XY", "{c}", FMT(u32_val));
+    StrReadFmt("XY", "{c}", u32_val);
     bool xy_pass = (ZstrCompareN((const char*)&u32_val, "XY", 2) == 0);
     printf("u32_val partial test: comparing memory with 'XY', pass = %s\n", xy_pass ? "true" : "false");
     success = success && xy_pass;
 
     u64_val = 0;
-    StrReadFmt("abc", "{c}", FMT(u64_val));
+    StrReadFmt("abc", "{c}", u64_val);
     bool abc_pass = (ZstrCompareN((const char*)&u64_val, "abc", 3) == 0);
     printf("u64_val partial test: comparing memory with 'abc', pass = %s\n", abc_pass ? "true" : "false");
     success = success && abc_pass;
 
     // Test that :c has no effect on string types (should work like regular string reading)
     Str str_val = StrInit();
-    StrReadFmt("Hello", "{c}", FMT(str_val));
+    StrReadFmt("Hello", "{c}", str_val);
 
     Str  expected = StrInitFromZstr("Hello");
     bool str_pass = (StrCmp(&str_val, &expected) == 0);
@@ -511,7 +511,7 @@ bool test_character_ordinal_reading(void) {
 
     // Test :c with quoted strings (should work like regular string reading)
     str_val = StrInit();
-    StrReadFmt("\"World\"", "{c}", FMT(str_val));
+    StrReadFmt("\"World\"", "{c}", str_val);
 
     expected             = StrInitFromZstr("World");
     bool quoted_str_pass = (StrCmp(&str_val, &expected) == 0);
@@ -535,7 +535,7 @@ bool test_string_case_conversion_reading(void) {
         Str         result = StrInit();
         const char* input  = "Hello World";
 
-        StrReadFmt(input, "{a}", FMT(result));
+        StrReadFmt(input, "{a}", result);
 
         printf("Test 1 - :a (lowercase)\n");
         printf("Input: '%s', Output: '", input);
@@ -559,7 +559,7 @@ bool test_string_case_conversion_reading(void) {
         Str         result = StrInit();
         const char* input  = "hello world";
 
-        StrReadFmt(input, "{A}", FMT(result));
+        StrReadFmt(input, "{A}", result);
 
         printf("Test 2 - :A (uppercase)\n");
         printf("Input: '%s', Output: '", input);
@@ -583,7 +583,7 @@ bool test_string_case_conversion_reading(void) {
         Str         result = StrInit();
         const char* input  = "\"MiXeD CaSe\"";
 
-        StrReadFmt(input, "{a}", FMT(result));
+        StrReadFmt(input, "{a}", result);
 
         printf("Test 3 - :a with quoted string\n");
         printf("Input: '%s', Output: '", input);
@@ -607,7 +607,7 @@ bool test_string_case_conversion_reading(void) {
         Str         result = StrInit();
         const char* input  = "\"abc123XYZ\"";
 
-        StrReadFmt(input, "{A}", FMT(result));
+        StrReadFmt(input, "{A}", result);
 
         printf("Test 4 - :A with mixed alphanumeric\n");
         printf("Input: '%s', Output: '", input);
@@ -631,7 +631,7 @@ bool test_string_case_conversion_reading(void) {
         Str         result = StrInit();
         const char* input  = "Hello World";
 
-        StrReadFmt(input, "{c}", FMT(result));
+        StrReadFmt(input, "{c}", result);
 
         printf("Test 5 - :c (no case conversion)\n");
         printf("Input: '%s', Output: '", input);
@@ -662,7 +662,7 @@ bool test_bitvec_reading(void) {
 
     // Test 1: Reading binary string
     BitVec bv1 = BitVecInit();
-    StrReadFmt("10110", "{}", FMT(bv1));
+    StrReadFmt("10110", "{}", bv1);
     Str result1 = BitVecToStr(&bv1);
     success     = success && (ZstrCompare(result1.data, "10110") == 0);
     printf(
@@ -676,7 +676,7 @@ bool test_bitvec_reading(void) {
 
     // Test 2: Reading hex format
     BitVec bv2 = BitVecInit();
-    StrReadFmt("0xDEAD", "{}", FMT(bv2));
+    StrReadFmt("0xDEAD", "{}", bv2);
     u64 value2 = BitVecToInteger(&bv2);
     success    = success && (value2 == 0xDEAD);
     printf("Test 2 - Hex: 0x%llx, Success: %s\n", value2, (value2 == 0xDEAD) ? "true" : "false");
@@ -684,7 +684,7 @@ bool test_bitvec_reading(void) {
 
     // Test 3: Reading octal format
     BitVec bv3 = BitVecInit();
-    StrReadFmt("0o755", "{}", FMT(bv3));
+    StrReadFmt("0o755", "{}", bv3);
     u64 value3 = BitVecToInteger(&bv3);
     success    = success && (value3 == 0755);
     printf("Test 3 - Octal: %llo, Success: %s\n", value3, (value3 == 0755) ? "true" : "false");
@@ -692,7 +692,7 @@ bool test_bitvec_reading(void) {
 
     // Test 4: Reading with whitespace
     BitVec bv4 = BitVecInit();
-    StrReadFmt("   1101", "{}", FMT(bv4));
+    StrReadFmt("   1101", "{}", bv4);
     Str result4 = BitVecToStr(&bv4);
     success     = success && (ZstrCompare(result4.data, "1101") == 0);
     printf(
@@ -706,7 +706,7 @@ bool test_bitvec_reading(void) {
 
     // Test 5: Reading zero values
     BitVec bv5 = BitVecInit();
-    StrReadFmt("0", "{}", FMT(bv5));
+    StrReadFmt("0", "{}", bv5);
     Str result5 = BitVecToStr(&bv5);
     success     = success && (ZstrCompare(result5.data, "0") == 0);
     printf(

--- a/Tests/Std/Io.Write.c
+++ b/Tests/Std/Io.Write.c
@@ -65,32 +65,32 @@ bool test_string_formatting(void) {
 
     // Test basic string
     const char* str = "Hello";
-    StrWriteFmt(&output, "{}", FMT(str));
+    StrWriteFmt(&output, "{}", str);
     success = success && (ZstrCompare(output.data, "Hello") == 0);
     StrClear(&output);
 
     // Test empty string
     const char* empty = "";
-    StrWriteFmt(&output, "{}", FMT(empty));
+    StrWriteFmt(&output, "{}", empty);
     success = success && (output.length == 0);
     StrClear(&output);
 
     // Test string with width and alignment
-    StrWriteFmt(&output, "{>10}", FMT(str));
+    StrWriteFmt(&output, "{>10}", str);
     success = success && (ZstrCompare(output.data, "     Hello") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{<10}", FMT(str));
+    StrWriteFmt(&output, "{<10}", str);
     success = success && (ZstrCompare(output.data, "Hello     ") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{^10}", FMT(str));
+    StrWriteFmt(&output, "{^10}", str);
     success = success && (ZstrCompare(output.data, "  Hello   ") == 0);
     StrClear(&output);
 
     // Test Str object
     Str s = StrInitFromZstr("World");
-    StrWriteFmt(&output, "{}", FMT(s));
+    StrWriteFmt(&output, "{}", s);
     success = success && (ZstrCompare(output.data, "World") == 0);
     StrDeinit(&s);
 
@@ -107,64 +107,64 @@ bool test_integer_decimal_formatting(void) {
 
     // Test signed integers
     i8 i8_val = -42;
-    StrWriteFmt(&output, "{}", FMT(i8_val));
+    StrWriteFmt(&output, "{}", i8_val);
     success = success && (ZstrCompare(output.data, "-42") == 0);
     StrClear(&output);
 
     i16 i16_val = -1234;
-    StrWriteFmt(&output, "{}", FMT(i16_val));
+    StrWriteFmt(&output, "{}", i16_val);
     success = success && (ZstrCompare(output.data, "-1234") == 0);
     StrClear(&output);
 
     i32 i32_val = -123456;
-    StrWriteFmt(&output, "{}", FMT(i32_val));
+    StrWriteFmt(&output, "{}", i32_val);
     success = success && (ZstrCompare(output.data, "-123456") == 0);
     StrClear(&output);
 
     i64 i64_val = -1234567890LL;
-    StrWriteFmt(&output, "{}", FMT(i64_val));
+    StrWriteFmt(&output, "{}", i64_val);
     success = success && (ZstrCompare(output.data, "-1234567890") == 0);
     StrClear(&output);
 
     // Test unsigned integers
     u8 u8_val = 42;
-    StrWriteFmt(&output, "{}", FMT(u8_val));
+    StrWriteFmt(&output, "{}", u8_val);
     success = success && (ZstrCompare(output.data, "42") == 0);
     StrClear(&output);
 
     u16 u16_val = 1234;
-    StrWriteFmt(&output, "{}", FMT(u16_val));
+    StrWriteFmt(&output, "{}", u16_val);
     success = success && (ZstrCompare(output.data, "1234") == 0);
     StrClear(&output);
 
     u32 u32_val = 123456;
-    StrWriteFmt(&output, "{}", FMT(u32_val));
+    StrWriteFmt(&output, "{}", u32_val);
     success = success && (ZstrCompare(output.data, "123456") == 0);
     StrClear(&output);
 
     u64 u64_val = 1234567890ULL;
-    StrWriteFmt(&output, "{}", FMT(u64_val));
+    StrWriteFmt(&output, "{}", u64_val);
     success = success && (ZstrCompare(output.data, "1234567890") == 0);
     StrClear(&output);
 
     // Test edge cases
     i8 i8_max = 127;
-    StrWriteFmt(&output, "{}", FMT(i8_max));
+    StrWriteFmt(&output, "{}", i8_max);
     success = success && (ZstrCompare(output.data, "127") == 0);
     StrClear(&output);
 
     i8 i8_min = -128;
-    StrWriteFmt(&output, "{}", FMT(i8_min));
+    StrWriteFmt(&output, "{}", i8_min);
     success = success && (ZstrCompare(output.data, "-128") == 0);
     StrClear(&output);
 
     u8 u8_max = 255;
-    StrWriteFmt(&output, "{}", FMT(u8_max));
+    StrWriteFmt(&output, "{}", u8_max);
     success = success && (ZstrCompare(output.data, "255") == 0);
     StrClear(&output);
 
     u8 u8_min = 0;
-    StrWriteFmt(&output, "{}", FMT(u8_min));
+    StrWriteFmt(&output, "{}", u8_min);
     success = success && (ZstrCompare(output.data, "0") == 0);
 
     StrDeinit(&output);
@@ -179,11 +179,11 @@ bool test_integer_hex_formatting(void) {
     bool success = true;
 
     u32 val = 0xDEADBEEF;
-    StrWriteFmt(&output, "{x}", FMT(val));
+    StrWriteFmt(&output, "{x}", val);
     success = success && (ZstrCompare(output.data, "0xdeadbeef") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{X}", FMT(val));
+    StrWriteFmt(&output, "{X}", val);
     success = success && (ZstrCompare(output.data, "0xDEADBEEF") == 0);
 
     StrDeinit(&output);
@@ -198,7 +198,7 @@ bool test_integer_binary_formatting(void) {
     bool success = true;
 
     u8 val = 0xA5; // 10100101 in binary
-    StrWriteFmt(&output, "{b}", FMT(val));
+    StrWriteFmt(&output, "{b}", val);
     success = success && (ZstrCompare(output.data, "0b10100101") == 0);
 
     StrDeinit(&output);
@@ -213,7 +213,7 @@ bool test_integer_octal_formatting(void) {
     bool success = true;
 
     u16 val = 0777;
-    StrWriteFmt(&output, "{o}", FMT(val));
+    StrWriteFmt(&output, "{o}", val);
     success = success && (ZstrCompare(output.data, "0o777") == 0);
 
     StrDeinit(&output);
@@ -228,12 +228,12 @@ bool test_float_basic_formatting(void) {
     bool success = true;
 
     f32 f32_val = 3.14159f;
-    StrWriteFmt(&output, "{}", FMT(f32_val));
+    StrWriteFmt(&output, "{}", f32_val);
     success = success && (ZstrCompare(output.data, "3.141590") == 0);
     StrClear(&output);
 
     f64 f64_val = 2.71828;
-    StrWriteFmt(&output, "{}", FMT(f64_val));
+    StrWriteFmt(&output, "{}", f64_val);
     success = success && (ZstrCompare(output.data, "2.718280") == 0);
 
     StrDeinit(&output);
@@ -250,15 +250,15 @@ bool test_float_precision_formatting(void) {
     f64 val = 3.14159265359;
 
     // Test different precisions
-    StrWriteFmt(&output, "{.2}", FMT(val));
+    StrWriteFmt(&output, "{.2}", val);
     success = success && (ZstrCompare(output.data, "3.14") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{.0}", FMT(val));
+    StrWriteFmt(&output, "{.0}", val);
     success = success && (ZstrCompare(output.data, "3") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{.10}", FMT(val));
+    StrWriteFmt(&output, "{.10}", val);
     success = success && (ZstrCompare(output.data, "3.1415926536") == 0);
 
     StrDeinit(&output);
@@ -274,18 +274,18 @@ bool test_float_special_values(void) {
 
     // Test infinity
     f64 pos_inf = INFINITY;
-    StrWriteFmt(&output, "{}", FMT(pos_inf));
+    StrWriteFmt(&output, "{}", pos_inf);
     success = success && (ZstrCompare(output.data, "inf") == 0);
     StrClear(&output);
 
     f64 neg_inf = -INFINITY;
-    StrWriteFmt(&output, "{}", FMT(neg_inf));
+    StrWriteFmt(&output, "{}", neg_inf);
     success = success && (ZstrCompare(output.data, "-inf") == 0);
     StrClear(&output);
 
     // Test NaN
     f64 nan_val = NAN;
-    StrWriteFmt(&output, "{}", FMT(nan_val));
+    StrWriteFmt(&output, "{}", nan_val);
     success = success && (ZstrCompare(output.data, "nan") == 0);
 
     StrDeinit(&output);
@@ -301,29 +301,29 @@ bool test_width_alignment_formatting(void) {
 
     // Test with integers
     i32 val = 42;
-    StrWriteFmt(&output, "{5}", FMT(val));
+    StrWriteFmt(&output, "{5}", val);
     success = success && (ZstrCompare(output.data, "   42") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{<5}", FMT(val));
+    StrWriteFmt(&output, "{<5}", val);
     success = success && (ZstrCompare(output.data, "42   ") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{^5}", FMT(val));
+    StrWriteFmt(&output, "{^5}", val);
     success = success && (ZstrCompare(output.data, " 42  ") == 0);
     StrClear(&output);
 
     // Test with strings
     const char* str = "abc";
-    StrWriteFmt(&output, "{5}", FMT(str));
+    StrWriteFmt(&output, "{5}", str);
     success = success && (ZstrCompare(output.data, "  abc") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{<5}", FMT(str));
+    StrWriteFmt(&output, "{<5}", str);
     success = success && (ZstrCompare(output.data, "abc  ") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{^5}", FMT(str));
+    StrWriteFmt(&output, "{^5}", str);
     success = success && (ZstrCompare(output.data, " abc ") == 0);
 
     StrDeinit(&output);
@@ -341,12 +341,12 @@ bool test_multiple_arguments(void) {
     i32         num   = 42;
     f64         pi    = 3.14;
 
-    StrWriteFmt(&output, "{} {} {}", FMT(hello), FMT(num), FMT(pi));
+    StrWriteFmt(&output, "{} {} {}", hello, num, pi);
     success = success && (ZstrCompare(output.data, "Hello 42 3.140000") == 0);
     StrClear(&output);
 
     // Instead of using positional arguments, we'll just reorder the arguments themselves
-    StrWriteFmt(&output, "{} {} {}", FMT(pi), FMT(hello), FMT(num));
+    StrWriteFmt(&output, "{} {} {}", pi, hello, num);
     success = success && (ZstrCompare(output.data, "3.140000 Hello 42") == 0);
 
     StrDeinit(&output);
@@ -362,17 +362,17 @@ bool test_char_formatting(void) {
 
     // Test mixed case string with :c (preserve case)
     const char* mixed_case = "MiXeD CaSe";
-    StrWriteFmt(&output, "{c}", FMT(mixed_case));
+    StrWriteFmt(&output, "{c}", mixed_case);
     success = success && (ZstrCompare(output.data, "MiXeD CaSe") == 0);
     StrClear(&output);
 
     // Test mixed case string with :a (lowercase)
-    StrWriteFmt(&output, "{a}", FMT(mixed_case));
+    StrWriteFmt(&output, "{a}", mixed_case);
     success = success && (ZstrCompare(output.data, "mixed case") == 0);
     StrClear(&output);
 
     // Test mixed case string with :A (uppercase)
-    StrWriteFmt(&output, "{A}", FMT(mixed_case));
+    StrWriteFmt(&output, "{A}", mixed_case);
     success = success && (ZstrCompare(output.data, "MIXED CASE") == 0);
     StrClear(&output);
 
@@ -380,17 +380,17 @@ bool test_char_formatting(void) {
     Str s = StrInitFromZstr("MiXeD CaSe");
 
     // Test with :c (preserve case)
-    StrWriteFmt(&output, "{c}", FMT(s));
+    StrWriteFmt(&output, "{c}", s);
     success = success && (ZstrCompare(output.data, "MiXeD CaSe") == 0);
     StrClear(&output);
 
     // Test with :a (lowercase)
-    StrWriteFmt(&output, "{a}", FMT(s));
+    StrWriteFmt(&output, "{a}", s);
     success = success && (ZstrCompare(output.data, "mixed case") == 0);
     StrClear(&output);
 
     // Test with :A (uppercase)
-    StrWriteFmt(&output, "{A}", FMT(s));
+    StrWriteFmt(&output, "{A}", s);
     success = success && (ZstrCompare(output.data, "MIXED CASE") == 0);
     StrClear(&output);
 
@@ -399,17 +399,17 @@ bool test_char_formatting(void) {
     u8 lower_char = 'm';
 
     // Test uppercase char with :c (preserve case)
-    StrWriteFmt(&output, "{c}", FMT(upper_char));
+    StrWriteFmt(&output, "{c}", upper_char);
     success = success && (ZstrCompare(output.data, "M") == 0);
     StrClear(&output);
 
     // Test uppercase char with :a (lowercase)
-    StrWriteFmt(&output, "{a}", FMT(upper_char));
+    StrWriteFmt(&output, "{a}", upper_char);
     success = success && (ZstrCompare(output.data, "m") == 0);
     StrClear(&output);
 
     // Test lowercase char with :A (uppercase)
-    StrWriteFmt(&output, "{A}", FMT(lower_char));
+    StrWriteFmt(&output, "{A}", lower_char);
     success = success && (ZstrCompare(output.data, "M") == 0);
     StrClear(&output);
 
@@ -417,17 +417,17 @@ bool test_char_formatting(void) {
     u16 u16_value = ('A' << 8) | 'B'; // AB in big-endian
 
     // Test u16 with :c (preserve case)
-    StrWriteFmt(&output, "{c}", FMT(u16_value));
+    StrWriteFmt(&output, "{c}", u16_value);
     success = success && (output.length == 2 && output.data[0] == 'A' && output.data[1] == 'B');
     StrClear(&output);
 
     // Test u16 with :a (lowercase)
-    StrWriteFmt(&output, "{a}", FMT(u16_value));
+    StrWriteFmt(&output, "{a}", u16_value);
     success = success && (output.length == 2 && output.data[0] == 'a' && output.data[1] == 'b');
     StrClear(&output);
 
     // Test u16 with :A (uppercase)
-    StrWriteFmt(&output, "{A}", FMT(u16_value));
+    StrWriteFmt(&output, "{A}", u16_value);
     success = success && (output.length == 2 && output.data[0] == 'A' && output.data[1] == 'B');
     StrClear(&output);
 
@@ -435,17 +435,17 @@ bool test_char_formatting(void) {
     i16 i16_value = ('C' << 8) | 'd'; // Cd in big-endian
 
     // Test i16 with :c (preserve case)
-    StrWriteFmt(&output, "{c}", FMT(i16_value));
+    StrWriteFmt(&output, "{c}", i16_value);
     success = success && (output.length == 2 && output.data[0] == 'C' && output.data[1] == 'd');
     StrClear(&output);
 
     // Test i16 with :a (lowercase)
-    StrWriteFmt(&output, "{a}", FMT(i16_value));
+    StrWriteFmt(&output, "{a}", i16_value);
     success = success && (output.length == 2 && output.data[0] == 'c' && output.data[1] == 'd');
     StrClear(&output);
 
     // Test i16 with :A (uppercase)
-    StrWriteFmt(&output, "{A}", FMT(i16_value));
+    StrWriteFmt(&output, "{A}", i16_value);
     success = success && (output.length == 2 && output.data[0] == 'C' && output.data[1] == 'D');
     StrClear(&output);
 
@@ -453,19 +453,19 @@ bool test_char_formatting(void) {
     u32 u32_value = ('E' << 24) | ('f' << 16) | ('G' << 8) | 'h'; // EfGh in big-endian
 
     // Test u32 with :c (preserve case)
-    StrWriteFmt(&output, "{c}", FMT(u32_value));
+    StrWriteFmt(&output, "{c}", u32_value);
     success = success && (output.length == 4 && output.data[0] == 'E' && output.data[1] == 'f' &&
                           output.data[2] == 'G' && output.data[3] == 'h');
     StrClear(&output);
 
     // Test u32 with :a (lowercase)
-    StrWriteFmt(&output, "{a}", FMT(u32_value));
+    StrWriteFmt(&output, "{a}", u32_value);
     success = success && (output.length == 4 && output.data[0] == 'e' && output.data[1] == 'f' &&
                           output.data[2] == 'g' && output.data[3] == 'h');
     StrClear(&output);
 
     // Test u32 with :A (uppercase)
-    StrWriteFmt(&output, "{A}", FMT(u32_value));
+    StrWriteFmt(&output, "{A}", u32_value);
     success = success && (output.length == 4 && output.data[0] == 'E' && output.data[1] == 'F' &&
                           output.data[2] == 'G' && output.data[3] == 'H');
     StrClear(&output);
@@ -474,19 +474,19 @@ bool test_char_formatting(void) {
     i32 i32_value = ('I' << 24) | ('j' << 16) | ('K' << 8) | 'l'; // IjKl in big-endian
 
     // Test i32 with :c (preserve case)
-    StrWriteFmt(&output, "{c}", FMT(i32_value));
+    StrWriteFmt(&output, "{c}", i32_value);
     success = success && (output.length == 4 && output.data[0] == 'I' && output.data[1] == 'j' &&
                           output.data[2] == 'K' && output.data[3] == 'l');
     StrClear(&output);
 
     // Test i32 with :a (lowercase)
-    StrWriteFmt(&output, "{a}", FMT(i32_value));
+    StrWriteFmt(&output, "{a}", i32_value);
     success = success && (output.length == 4 && output.data[0] == 'i' && output.data[1] == 'j' &&
                           output.data[2] == 'k' && output.data[3] == 'l');
     StrClear(&output);
 
     // Test i32 with :A (uppercase)
-    StrWriteFmt(&output, "{A}", FMT(i32_value));
+    StrWriteFmt(&output, "{A}", i32_value);
     success = success && (output.length == 4 && output.data[0] == 'I' && output.data[1] == 'J' &&
                           output.data[2] == 'K' && output.data[3] == 'L');
     StrClear(&output);
@@ -496,21 +496,21 @@ bool test_char_formatting(void) {
                     ('r' << 16) | ('S' << 8) | 't'; // MnOpQrSt in big-endian
 
     // Test u64 with :c (preserve case)
-    StrWriteFmt(&output, "{c}", FMT(u64_value));
+    StrWriteFmt(&output, "{c}", u64_value);
     success = success && (output.length == 8 && output.data[0] == 'M' && output.data[1] == 'n' &&
                           output.data[2] == 'O' && output.data[3] == 'p' && output.data[4] == 'Q' &&
                           output.data[5] == 'r' && output.data[6] == 'S' && output.data[7] == 't');
     StrClear(&output);
 
     // Test u64 with :a (lowercase)
-    StrWriteFmt(&output, "{a}", FMT(u64_value));
+    StrWriteFmt(&output, "{a}", u64_value);
     success = success && (output.length == 8 && output.data[0] == 'm' && output.data[1] == 'n' &&
                           output.data[2] == 'o' && output.data[3] == 'p' && output.data[4] == 'q' &&
                           output.data[5] == 'r' && output.data[6] == 's' && output.data[7] == 't');
     StrClear(&output);
 
     // Test u64 with :A (uppercase)
-    StrWriteFmt(&output, "{A}", FMT(u64_value));
+    StrWriteFmt(&output, "{A}", u64_value);
     success = success && (output.length == 8 && output.data[0] == 'M' && output.data[1] == 'N' &&
                           output.data[2] == 'O' && output.data[3] == 'P' && output.data[4] == 'Q' &&
                           output.data[5] == 'R' && output.data[6] == 'S' && output.data[7] == 'T');
@@ -521,21 +521,21 @@ bool test_char_formatting(void) {
                     ('z' << 16) | ('1' << 8) | '2'; // UvWxYz12 in big-endian
 
     // Test i64 with :c (preserve case)
-    StrWriteFmt(&output, "{c}", FMT(i64_value));
+    StrWriteFmt(&output, "{c}", i64_value);
     success = success && (output.length == 8 && output.data[0] == 'U' && output.data[1] == 'v' &&
                           output.data[2] == 'W' && output.data[3] == 'x' && output.data[4] == 'Y' &&
                           output.data[5] == 'z' && output.data[6] == '1' && output.data[7] == '2');
     StrClear(&output);
 
     // Test i64 with :a (lowercase)
-    StrWriteFmt(&output, "{a}", FMT(i64_value));
+    StrWriteFmt(&output, "{a}", i64_value);
     success = success && (output.length == 8 && output.data[0] == 'u' && output.data[1] == 'v' &&
                           output.data[2] == 'w' && output.data[3] == 'x' && output.data[4] == 'y' &&
                           output.data[5] == 'z' && output.data[6] == '1' && output.data[7] == '2');
     StrClear(&output);
 
     // Test i64 with :A (uppercase)
-    StrWriteFmt(&output, "{A}", FMT(i64_value));
+    StrWriteFmt(&output, "{A}", i64_value);
     success = success && (output.length == 8 && output.data[0] == 'U' && output.data[1] == 'V' &&
                           output.data[2] == 'W' && output.data[3] == 'X' && output.data[4] == 'Y' &&
                           output.data[5] == 'Z' && output.data[6] == '1' && output.data[7] == '2');
@@ -554,53 +554,53 @@ bool test_bitvec_formatting(void) {
 
     // Test 1: Basic binary formatting
     BitVec bv1 = BitVecFromStr("10110");
-    StrWriteFmt(&output, "{}", FMT(bv1));
+    StrWriteFmt(&output, "{}", bv1);
     success = success && (ZstrCompare(output.data, "10110") == 0);
     StrClear(&output);
 
     // Test 2: Empty BitVec
     BitVec bv_empty = BitVecInit();
-    StrWriteFmt(&output, "{}", FMT(bv_empty));
+    StrWriteFmt(&output, "{}", bv_empty);
     success = success && (output.length == 0);
     StrClear(&output);
 
     // Test 3: Hex formatting
     BitVec bv2 = BitVecFromInteger(0xABCD, 16);
-    StrWriteFmt(&output, "{x}", FMT(bv2));
+    StrWriteFmt(&output, "{x}", bv2);
     success = success && (ZstrCompare(output.data, "0xabcd") == 0);
     StrClear(&output);
 
     // Test 4: Uppercase hex formatting
-    StrWriteFmt(&output, "{X}", FMT(bv2));
+    StrWriteFmt(&output, "{X}", bv2);
     success = success && (ZstrCompare(output.data, "0xABCD") == 0);
     StrClear(&output);
 
     // Test 5: Octal formatting
     BitVec bv3 = BitVecFromInteger(0755, 10);
-    StrWriteFmt(&output, "{o}", FMT(bv3));
+    StrWriteFmt(&output, "{o}", bv3);
     success = success && (ZstrCompare(output.data, "0o755") == 0);
     StrClear(&output);
 
     // Test 6: Width and alignment
-    StrWriteFmt(&output, "{>10}", FMT(bv1));
+    StrWriteFmt(&output, "{>10}", bv1);
     success = success && (ZstrCompare(output.data, "     10110") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{<10}", FMT(bv1));
+    StrWriteFmt(&output, "{<10}", bv1);
     success = success && (ZstrCompare(output.data, "10110     ") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{^10}", FMT(bv1));
+    StrWriteFmt(&output, "{^10}", bv1);
     success = success && (ZstrCompare(output.data, "  10110   ") == 0);
     StrClear(&output);
 
     // Test 7: Zero value
     BitVec bv_zero = BitVecFromInteger(0, 1);
-    StrWriteFmt(&output, "{x}", FMT(bv_zero));
+    StrWriteFmt(&output, "{x}", bv_zero);
     success = success && (ZstrCompare(output.data, "0x0") == 0);
     StrClear(&output);
 
-    StrWriteFmt(&output, "{o}", FMT(bv_zero));
+    StrWriteFmt(&output, "{o}", bv_zero);
     success = success && (ZstrCompare(output.data, "0o0") == 0);
     StrClear(&output);
 

--- a/Tests/Std/Str.Foreach.Simple.c
+++ b/Tests/Std/Str.Foreach.Simple.c
@@ -29,7 +29,7 @@ bool test_str_foreach_idx(void) {
 
     // Build a new string by iterating through each character with its index
     Str result = StrInit();
-    StrForeachIdx(&s, chr, idx, { StrWriteFmt(&result, "{c}{}", FMT(chr), FMT(idx)); });
+    StrForeachIdx(&s, chr, idx, { StrWriteFmt(&result, "{c}{}", chr, idx); });
 
     // The result should be "H0e1l2l3o4"
     bool success = (ZstrCompare(result.data, "H0e1l2l3o4") == 0);
@@ -56,7 +56,7 @@ bool test_str_foreach_reverse_idx(void) {
         }
 
         // Append the character and its index to the result string
-        StrWriteFmt(&result, "{c}{}", FMT(chr), FMT(idx));
+        StrWriteFmt(&result, "{c}{}", chr, idx);
     });
 
     // The expected result depends on whether index 0 is processed
@@ -85,7 +85,7 @@ bool test_str_foreach_ptr_idx(void) {
     Str result = StrInit();
     StrForeachPtrIdx(&s, chrptr, idx, {
         // Append the character (via pointer) and its index to the result string
-        StrWriteFmt(&result, "{c}{}", FMT(*chrptr), FMT(idx));
+        StrWriteFmt(&result, "{c}{}", *chrptr, idx);
 
         // Modify the original string by converting to uppercase
         if (*chrptr >= 'a' && *chrptr <= 'z') {
@@ -121,7 +121,7 @@ bool test_str_foreach_reverse_ptr_idx(void) {
         }
 
         // Append the character (via pointer) and its index to the result string
-        StrWriteFmt(&result, "{c}{}", FMT(*chrptr), FMT(idx));
+        StrWriteFmt(&result, "{c}{}", *chrptr, idx);
 
         // Modify the original string by converting to uppercase
         if (*chrptr >= 'a' && *chrptr <= 'z') {
@@ -277,7 +277,7 @@ bool test_str_foreach_in_range_idx(void) {
     Str result = StrInit();
     StrForeachInRangeIdx(&s, chr, idx, 6, 11, {
         // Append the character and its index to the result string
-        StrWriteFmt(&result, "{c}{}", FMT(chr), FMT(idx));
+        StrWriteFmt(&result, "{c}{}", chr, idx);
     });
 
     // The result should be "W6o7r8l9d10" (characters from index 6-10 with their indices)
@@ -341,7 +341,7 @@ bool test_str_foreach_ptr_in_range_idx(void) {
     Str result = StrInit();
     StrForeachPtrInRangeIdx(&s, chrptr, idx, 6, 11, {
         // Append the character and its index to the result string
-        StrWriteFmt(&result, "{c}{}", FMT(*chrptr), FMT(idx));
+        StrWriteFmt(&result, "{c}{}", *chrptr, idx);
 
         // Modify the original string by converting to uppercase
         if (*chrptr >= 'a' && *chrptr <= 'z') {


### PR DESCRIPTION
This PR makes the syntax of using  FmtIO macros easier.

Old method :

```c
WriteFmtLn("Here's a number for you : {}", FMT(LVAL(10)));
```

Now : 

```c
WriteFmtLn("Here's a number for you : {}", 10);
```