### PR TITLE
Fix Compilation Error On Manjaro Intel Mac & Add Dependency To meson.build

### DIFF
--- a/Source/Misra/Std/Io.c
+++ b/Source/Misra/Std/Io.c
@@ -6,7 +6,6 @@
 
 // Required for fileno
 // Reference : https://forums.freebsd.org/threads/strerror_r-best-practices-posix-vs-gnu.92296/
-#include <stdio.h>
 #define _POSIX_C_SOURCE 200112L
 
 #include <Misra/Std/Io.h>
@@ -18,6 +17,7 @@
 // stdc
 #include <ctype.h>
 #include <math.h>
+#include <stdio.h>
 
 static void _write_r8(Str* o, FmtInfo* fmt_info, u8* v);
 static void _write_r16(Str* o, FmtInfo* fmt_info, u16* v);

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,13 @@ misra_std = static_library(
     install: true
 )
 
+# Dependency for working with other projects
+misra_std_dep = declare_dependency(
+    include_directories : inc_misra,
+    link_with: misra_std,
+    dependencies: [math_dep],
+)
+
 # Non-sanitized library specifically for deadend tests to avoid memory leak reports
 misra_std_no_sanitizers = static_library(
     'misra_std_no_sanitizers',


### PR DESCRIPTION
posix source feature flag must be defined before including studio on Linux so did that. Also added some variables to easily include this project as a meson dependency