### PR TITLE
Make IOFMT More Robust

### DIFF
--- a/Include/Misra/Std/Io.h
+++ b/Include/Misra/Std/Io.h
@@ -135,18 +135,20 @@ static inline TypeSpecificIO TO_TYPE_SPECIFIC_IO_IMPL(TypeSpecificWriter w, Type
             BitVec: TO_TYPE_SPECIFIC_IO(BitVec, &(x)),                                                                 \
             const char *: TO_TYPE_SPECIFIC_IO(Zstr, &(x)),                                                             \
             char *: TO_TYPE_SPECIFIC_IO(Zstr, &(x)),                                                                   \
-            u8: TO_TYPE_SPECIFIC_IO(u8, &(x)),                                                                         \
-            u16: TO_TYPE_SPECIFIC_IO(u16, &(x)),                                                                       \
-            u32: TO_TYPE_SPECIFIC_IO(u32, &(x)),                                                                       \
-            u64: TO_TYPE_SPECIFIC_IO(u64, &(x)),                                                                       \
-            i8: TO_TYPE_SPECIFIC_IO(i8, &(x)),                                                                         \
-            i16: TO_TYPE_SPECIFIC_IO(i16, &(x)),                                                                       \
-            i32: TO_TYPE_SPECIFIC_IO(i32, &(x)),                                                                       \
-            i64: TO_TYPE_SPECIFIC_IO(i64, &(x)),                                                                       \
+            unsigned char: TO_TYPE_SPECIFIC_IO(u8, &(x)),                                                              \
+            unsigned short: TO_TYPE_SPECIFIC_IO(u16, &(x)),                                                            \
+            unsigned int: TO_TYPE_SPECIFIC_IO(u32, &(x)),                                                              \
+            unsigned long: sizeof(unsigned long) == 4 ? TO_TYPE_SPECIFIC_IO(u32, &(x)) :                               \
+                                                        TO_TYPE_SPECIFIC_IO(u64, &(x)),                                \
+            unsigned long long: TO_TYPE_SPECIFIC_IO(u64, &(x)),                                                        \
+            signed char: TO_TYPE_SPECIFIC_IO(i8, &(x)),                                                                \
+            signed short: TO_TYPE_SPECIFIC_IO(i16, &(x)),                                                              \
+            signed int: TO_TYPE_SPECIFIC_IO(i32, &(x)),                                                                \
+            signed long: sizeof(signed long) == 4 ? TO_TYPE_SPECIFIC_IO(i32, &(x)) : TO_TYPE_SPECIFIC_IO(i64, &(x)),   \
+            signed long long: TO_TYPE_SPECIFIC_IO(i64, &(x)),                                                          \
             f32: TO_TYPE_SPECIFIC_IO(f32, &(x)),                                                                       \
             f64: TO_TYPE_SPECIFIC_IO(f64, &(x)),                                                                       \
             char: TO_TYPE_SPECIFIC_IO(i8, &(x)),                                                                       \
-            unsigned long: TO_TYPE_SPECIFIC_IO(u64, &(x)),                                                             \
             default: TO_TYPE_SPECIFIC_IO(UnsupportedType, NULL)                                                        \
         )
 #else
@@ -166,18 +168,21 @@ static inline TypeSpecificIO TO_TYPE_SPECIFIC_IO_IMPL(TypeSpecificWriter w, Type
             BitVec: TO_TYPE_SPECIFIC_IO(BitVec, (void *)&(x)),                                                         \
             const char *: TO_TYPE_SPECIFIC_IO(Zstr, (void *)&(x)),                                                     \
             char *: TO_TYPE_SPECIFIC_IO(Zstr, (void *)&(x)),                                                           \
-            u8: TO_TYPE_SPECIFIC_IO(u8, (void *)&(x)),                                                                 \
-            u16: TO_TYPE_SPECIFIC_IO(u16, (void *)&(x)),                                                               \
-            u32: TO_TYPE_SPECIFIC_IO(u32, (void *)&(x)),                                                               \
-            u64: TO_TYPE_SPECIFIC_IO(u64, (void *)&(x)),                                                               \
-            i8: TO_TYPE_SPECIFIC_IO(i8, (void *)&(x)),                                                                 \
-            i16: TO_TYPE_SPECIFIC_IO(i16, (void *)&(x)),                                                               \
-            i32: TO_TYPE_SPECIFIC_IO(i32, (void *)&(x)),                                                               \
-            i64: TO_TYPE_SPECIFIC_IO(i64, (void *)&(x)),                                                               \
+            unsigned char: TO_TYPE_SPECIFIC_IO(u8, (void *)&(x)),                                                      \
+            unsigned short: TO_TYPE_SPECIFIC_IO(u16, (void *)&(x)),                                                    \
+            unsigned int: TO_TYPE_SPECIFIC_IO(u32, (void *)&(x)),                                                      \
+            unsigned long: sizeof(unsigned long) == 4 ? TO_TYPE_SPECIFIC_IO(u32, (void *)&(x)) :                       \
+                                                        TO_TYPE_SPECIFIC_IO(u64, (void *)&(x)),                        \
+            unsigned long long: TO_TYPE_SPECIFIC_IO(u64, (void *)&(x)),                                                \
+            signed char: TO_TYPE_SPECIFIC_IO(i8, (void *)&(x)),                                                        \
+            signed short: TO_TYPE_SPECIFIC_IO(i16, (void *)&(x)),                                                      \
+            signed int: TO_TYPE_SPECIFIC_IO(i32, (void *)&(x)),                                                        \
+            signed long: sizeof(signed long) == 4 ? TO_TYPE_SPECIFIC_IO(i32, (void *)&(x)) :                           \
+                                                    TO_TYPE_SPECIFIC_IO(i64, (void *)&(x)),                            \
+            signed long long: TO_TYPE_SPECIFIC_IO(i64, (void *)&(x)),                                                  \
             f32: TO_TYPE_SPECIFIC_IO(f32, (void *)&(x)),                                                               \
             f64: TO_TYPE_SPECIFIC_IO(f64, (void *)&(x)),                                                               \
             char: TO_TYPE_SPECIFIC_IO(i8, (void *)&(x)),                                                               \
-            size: TO_TYPE_SPECIFIC_IO(u64, (void *)&(x)),                                                              \
             default: TO_TYPE_SPECIFIC_IO(UnsupportedType, NULL)                                                        \
         )
 #endif


### PR DESCRIPTION
Earlier I used my own defined types like `i32`, `u64`, etc.. in  defining the `_Generic` body of  `IOFMT` macro. Now I define it using full type names like `unsigned char`, or `signed long` or `singed long long`, etc... Earlier solution was not very good with external libraries like Zydis that defined their own types (just like me). Turns out that I only need to make a case for each compatible type. That's what I did in this PR and it works!!