### PR TITLE
Add LOG_SYS_{FATAL,ERROR,INFO} To Avoid Using SysStrError Everytime

### DIFF
--- a/Include/Misra/Std/Log.h
+++ b/Include/Misra/Std/Log.h
@@ -31,10 +31,10 @@ void SysAbort(void);
 ///
 #define LOG_FATAL(...)                                                                                                 \
     do {                                                                                                               \
-        Str m = StrInit();                                                                                             \
-        StrWriteFmt(&m, __VA_ARGS__);                                                                                  \
-        LogWrite(LOG_MESSAGE_TYPE_FATAL, __func__, __LINE__, m.data);                                                  \
-        StrDeinit(&m);                                                                                                 \
+        Str m_##__LINE__ = StrInit();                                                                                  \
+        StrWriteFmt(&m_##__LINE__, __VA_ARGS__);                                                                       \
+        LogWrite(LOG_MESSAGE_TYPE_FATAL, __func__, __LINE__, m_##__LINE__.data);                                       \
+        StrDeinit(&m_##__LINE__);                                                                                      \
         SysAbort();                                                                                                    \
     } while (0)
 
@@ -50,10 +50,10 @@ void SysAbort(void);
 ///
 #define LOG_ERROR(...)                                                                                                 \
     do {                                                                                                               \
-        Str m = StrInit();                                                                                             \
-        StrWriteFmt(&m, __VA_ARGS__);                                                                                  \
-        LogWrite(LOG_MESSAGE_TYPE_ERROR, __func__, __LINE__, m.data);                                                  \
-        StrDeinit(&m);                                                                                                 \
+        Str m_##__LINE__ = StrInit();                                                                                  \
+        StrWriteFmt(&m_##__LINE__, __VA_ARGS__);                                                                       \
+        LogWrite(LOG_MESSAGE_TYPE_ERROR, __func__, __LINE__, m_##__LINE__.data);                                       \
+        StrDeinit(&m_##__LINE__);                                                                                      \
     } while (0)
 
 ///
@@ -68,10 +68,80 @@ void SysAbort(void);
 ///
 #define LOG_INFO(...)                                                                                                  \
     do {                                                                                                               \
-        Str m = StrInit();                                                                                             \
-        StrWriteFmt(&m, __VA_ARGS__);                                                                                  \
-        LogWrite(LOG_MESSAGE_TYPE_INFO, __func__, __LINE__, m.data);                                                   \
-        StrDeinit(&m);                                                                                                 \
+        Str m_##__LINE__ = StrInit();                                                                                  \
+        StrWriteFmt(&m_##__LINE__, __VA_ARGS__);                                                                       \
+        LogWrite(LOG_MESSAGE_TYPE_INFO, __func__, __LINE__, m_##__LINE__.data);                                        \
+        StrDeinit(&m_##__LINE__);                                                                                      \
+    } while (0)
+
+///
+/// Writes a fatal log message and aborts the program.
+///
+/// ...[in] : Format string and arguments following printf-style syntax.
+///
+/// SUCCESS: Message logged and program aborted via abort()
+/// FAILURE: Logging may fail silently, but abort() will still execute
+///
+/// TAGS: Logging, Macro, Fatal, System
+///
+#define LOG_SYS_FATAL(...)                                                                                             \
+    do {                                                                                                               \
+        Str m_##__LINE__ = StrInit();                                                                                  \
+        StrWriteFmt(&m_##__LINE__, __VA_ARGS__);                                                                       \
+        Str syserr_##__LINE__;                                                                                         \
+        StrInitStack(syserr_##__LINE__, 256, {                                                                         \
+            SysStrError(errno, &syserr_##__LINE__);                                                                    \
+            StrWriteFmt(&m_##__LINE__, " : {}", syserr_##__LINE__);                                                    \
+        });                                                                                                            \
+        LogWrite(LOG_MESSAGE_TYPE_FATAL, __func__, __LINE__, m_##__LINE__.data);                                       \
+        StrDeinit(&m_##__LINE__);                                                                                      \
+        SysAbort();                                                                                                    \
+    } while (0)
+
+///
+/// Writes an error-level log message.
+///
+/// ...[in] : Format string and arguments following printf-style syntax.
+///
+/// SUCCESS: Error message written to log output
+/// FAILURE: Logging fails silently (output not guaranteed)
+///
+/// TAGS: Logging, Macro, Error, System
+///
+#define LOG_SYS_ERROR(...)                                                                                             \
+    do {                                                                                                               \
+        Str m_##__LINE__ = StrInit();                                                                                  \
+        StrWriteFmt(&m_##__LINE__, __VA_ARGS__);                                                                       \
+        Str syserr_##__LINE__;                                                                                         \
+        StrInitStack(syserr_##__LINE__, 256, {                                                                         \
+            SysStrError(errno, &syserr_##__LINE__);                                                                    \
+            StrWriteFmt(&m_##__LINE__, " : {}", syserr_##__LINE__);                                                    \
+        });                                                                                                            \
+        LogWrite(LOG_MESSAGE_TYPE_ERROR, __func__, __LINE__, m_##__LINE__.data);                                       \
+        StrDeinit(&m_##__LINE__);                                                                                      \
+    } while (0)
+
+///
+/// Writes an informational log message.
+///
+/// ...[in] : Format string and arguments following printf-style syntax.
+///
+/// SUCCESS: Informational message written to log output
+/// FAILURE: Logging fails silently (output not guaranteed)
+///
+/// TAGS: Logging, Macro, Info, System
+///
+#define LOG_SYS_INFO(...)                                                                                              \
+    do {                                                                                                               \
+        Str m_##__LINE__ = StrInit();                                                                                  \
+        StrWriteFmt(&m_##__LINE__, __VA_ARGS__);                                                                       \
+        Str syserr_##__LINE__;                                                                                         \
+        StrInitStack(syserr_##__LINE__, 256, {                                                                         \
+            SysStrError(errno, &syserr_##__LINE__);                                                                    \
+            StrWriteFmt(&m_##__LINE__, " : {}", syserr_##__LINE__);                                                    \
+        });                                                                                                            \
+        LogWrite(LOG_MESSAGE_TYPE_INFO, __func__, __LINE__, m_##__LINE__.data);                                        \
+        StrDeinit(&m_##__LINE__);                                                                                      \
     } while (0)
 
 ///

--- a/Include/Misra/Std/Log.h
+++ b/Include/Misra/Std/Log.h
@@ -75,7 +75,10 @@ void SysAbort(void);
     } while (0)
 
 ///
-/// Writes a fatal log message and aborts the program.
+/// Writes a fatal log message and aborts the program, with `errno` explanation appended
+/// at the end of final string.
+///
+/// INFO: Think of this as `perror()` with `LOG`
 ///
 /// ...[in] : Format string and arguments following printf-style syntax.
 ///
@@ -99,7 +102,10 @@ void SysAbort(void);
     } while (0)
 
 ///
-/// Writes an error-level log message.
+/// Writes an error-level log message with `errno` explanation appended
+/// at the end of final string.
+///
+/// INFO: Think of this as `perror()` with `LOG`
 ///
 /// ...[in] : Format string and arguments following printf-style syntax.
 ///
@@ -122,7 +128,10 @@ void SysAbort(void);
     } while (0)
 
 ///
-/// Writes an informational log message.
+/// Writes an informational log message along with errno explanation appended
+/// at then end of final string.
+///
+/// INFO: Think of this like `perror()` but as `LOG` macros
 ///
 /// ...[in] : Format string and arguments following printf-style syntax.
 ///

--- a/Source/Misra/Std/Container/BitVec.c
+++ b/Source/Misra/Std/Container/BitVec.c
@@ -38,7 +38,7 @@
 void BitVecDeinit(BitVec *bitvec) {
     ValidateBitVec(bitvec);
     if (bitvec->data) {
-        free(bitvec->data);
+        FREE(bitvec->data);
         bitvec->data = NULL;
     }
     bitvec->length    = 0;
@@ -109,7 +109,7 @@ void BitVecShrinkToFit(BitVec *bv) {
     ValidateBitVec(bv);
     if (bv->length == 0) {
         // Free all memory if empty
-        free(bv->data);
+        FREE(bv->data);
         bv->data      = NULL;
         bv->capacity  = 0;
         bv->byte_size = 0;
@@ -1257,10 +1257,8 @@ u64 BitVecEditDistance(BitVec *bv1, BitVec *bv2) {
     u64 *curr_row = malloc((len2 + 1) * sizeof(u64));
 
     if (!prev_row || !curr_row) {
-        if (prev_row)
-            free(prev_row);
-        if (curr_row)
-            free(curr_row);
+        FREE(prev_row);
+        FREE(curr_row);
         LOG_FATAL("Memory allocation failed");
     }
 
@@ -1290,8 +1288,8 @@ u64 BitVecEditDistance(BitVec *bv1, BitVec *bv2) {
     }
 
     u64 result = prev_row[len2];
-    free(prev_row);
-    free(curr_row);
+    FREE(prev_row);
+    FREE(curr_row);
 
     return result;
 }

--- a/Source/Misra/Std/Container/Vec.c
+++ b/Source/Misra/Std/Container/Vec.c
@@ -87,11 +87,7 @@ void reserve_vec(GenericVec *vec, size item_size, size n) {
         // this way, actual capacity is always at least one greater than length of vector (as required for strings)
         char *ptr = realloc(vec->data, (n + 1) * vec_aligned_size(vec, item_size));
         if (!ptr) {
-            Str syserr;
-            StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
-                SysStrError(errno, &syserr);
-                LOG_FATAL("realloc() failed : {}", syserr);
-            });
+            LOG_SYS_FATAL("realloc() failed");
         }
         // it's mandatory to set the pointer here, because next call to any vec_ will do a validation check
         // this could've resulted in a heap-use-after-free bug, which was caught with help of ValidateVec
@@ -136,11 +132,7 @@ void reduce_space_vec(GenericVec *vec, size item_size) {
         // again make sure that actual capacity is at least one greater than length of vector (required for strings)
         ptr = realloc(vec->data, (vec->length + 1) * vec_aligned_size(vec, item_size));
         if (!ptr) {
-            Str syserr;
-            StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
-                SysStrError(errno, &syserr);
-                LOG_FATAL("realloc() failed : {}", syserr);
-            });
+            LOG_SYS_FATAL("realloc() failed");
         }
         vec->capacity = vec->length;
         vec->data     = ptr;

--- a/Source/Misra/Std/File.c
+++ b/Source/Misra/Std/File.c
@@ -31,11 +31,7 @@ bool ReadCompleteFile(const char *filename, char **data, u64 *file_size, u64 *ca
         buffer = realloc(buffer, fsize + 1);
 
         if (!buffer) {
-            Str syserr;
-            StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
-                SysStrError(errno, &syserr);
-                LOG_FATAL("malloc() failed : {}", syserr);
-            });
+            LOG_SYS_FATAL("malloc() failed");
         }
 
         *capacity = fsize + 1;
@@ -54,25 +50,14 @@ bool ReadCompleteFile(const char *filename, char **data, u64 *file_size, u64 *ca
 #endif
     if (e || !file) {
         free(buffer);
-
-        Str syserr = StrInit();
-        StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
-            SysStrError(e, &syserr);
-            LOG_ERROR("fopen() failed : {}", syserr);
-        });
-
+        LOG_SYS_ERROR("fopen() failed");
         return false;
     }
 
     // Read the entire file into the buffer
     if (fsize != (i64)fread(buffer, 1, fsize, file)) {
         fclose(file);
-        Str syserr = StrInit();
-        StrInitStack(syserr, SYS_ERROR_STR_MAX_LENGTH, {
-            SysStrError(errno, &syserr);
-            LOG_ERROR("failed to read complete file. : {}", syserr);
-        });
-
+        LOG_SYS_ERROR("Failed to read complete file");
         return false;
     }
 

--- a/Source/Misra/Std/Io.c
+++ b/Source/Misra/Std/Io.c
@@ -615,10 +615,7 @@ void FReadFmtInternal(FILE* file, const char* fmtstr, TypeSpecificIO* argv, size
         if (fgetpos(file, &start_pos) == 0) {
             can_rollback = true;
         } else {
-            Str err = StrInit();
-            SysStrError(errno, &err);
-            LOG_ERROR("Could not save file position for rollback: {}", err);
-            StrDeinit(&err);
+            LOG_SYS_ERROR("Could not save file position for rollback");
         }
     }
 

--- a/Source/Misra/Std/Log.c
+++ b/Source/Misra/Std/Log.c
@@ -34,6 +34,7 @@ void LogInit(bool redirect) {
                 SysStrError(errno, &syserr);
                 LOG_ERROR("Failed to get localtime : {}", syserr);
             });
+            LOG_SYS_ERROR("Failed to get localtime");
             goto LOG_STREAM_FALLBACK;
         }
         strftime(time_buffer, sizeof(time_buffer), "%Y-%m-%d-%H-%M-%S", &time_info);

--- a/Source/Misra/Sys.c
+++ b/Source/Misra/Sys.c
@@ -158,11 +158,7 @@ SysDirContents SysGetDirContents(const char* path) {
 
     DIR* dir = opendir(path);
     if (NULL == dir) {
-        Str err;
-        StrInitStack(err, SYS_ERROR_STR_MAX_LENGTH, {
-            SysStrError(errno, &err);
-            LOG_ERROR("opendir(\"{}\") failed : {}", path, err);
-        });
+        LOG_SYS_ERROR("opendir(\"{}\") failed", path);
         return (SysDirContents) {0};
     }
 
@@ -229,21 +225,13 @@ i64 SysGetFileSize(const char* filename) {
     // Windows-specific code using GetFileSizeEx
     HANDLE file = CreateFileA(filename, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
     if (file == INVALID_HANDLE_VALUE) {
-        Str err;
-        StrInitStack(err, SYS_ERROR_STR_MAX_LENGTH, {
-            SysStrError(errno, &err);
-            LOG_ERROR("failed to open file: {}\n", err);
-        });
+        LOG_SYS_ERROR("CreateFileA() failed");
         return -1;
     }
 
     LARGE_INTEGER file_size;
     if (!GetFileSizeEx(file, &file_size)) {
-        Str err;
-        StrInitStack(err, SYS_ERROR_STR_MAX_LENGTH, {
-            SysStrError(errno, &err);
-            LOG_ERROR("failed to get file size: {}\n", err);
-        });
+        LOG_SYS_ERROR("GetFileSizeEx() failed");
         CloseHandle(file);
         return -1;
     }
@@ -256,11 +244,7 @@ i64 SysGetFileSize(const char* filename) {
     if (stat(filename, &file_stat) == 0) {
         return (i64)file_stat.st_size;
     } else {
-        Str err;
-        StrInitStack(err, SYS_ERROR_STR_MAX_LENGTH, {
-            SysStrError(errno, &err);
-            LOG_ERROR("failed to get file size: {}\n", err);
-        });
+        LOG_SYS_ERROR("stat() failed");
         return -1;
     }
 #endif


### PR DESCRIPTION
```c
        StrInitStack(errstr, 256, {
            SysStrError(errno, &errstr);
            LOG_ERROR("socket() : {}", errstr);
            return EXIT_FAILURE;
        });
```

There's this ugly pattern everywhere, where there is a need to print error string for `errno` along with a log message. This pattern is repetitive, and is used everywhere in a way like this. Now there are three new macros to _DRY_ out this pattern :

- `LOG_SYS_FATAL` : `LOG_FATAL` with `: <errstr>` appended at the end of log message automatically
- `LOG_SYS_ERROR` : Same as above but with `LOG_ERROR`
- `LOG_SYS_INFO` : You get the idea :-)