### PR TITLE
StrReadFmt Updates Read Position In Provided Input

### DIFF
--- a/Include/Misra/Std/Io.h
+++ b/Include/Misra/Std/Io.h
@@ -302,6 +302,28 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 /// Parse input string according to format string with rust-style placeholders,
 /// extracting values into provided arguments. This is a macro wrapper around StrReadFmtInternal.
 ///
+/// NOTE: Provided input string must be an assignable l-value. The macro automatically updates given
+///       input string to new parse position after a successful parse. If parse fails, the input string
+///       pointers does not change.
+///
+/// WARN: Do not free given input after use. Pointer value is changed after successful read. It can be
+///       like `(input) + 1` or `(input + 1233493783847394)` which are invalid pointers to be called `FREE` upon.
+///
+/// WARN: Not providing an assingable input (first parameter) will result in undefined behavior.
+///       If you're lucky you'll get a segfault.
+///
+/// INFO: The new `input` value after a successful read will be in [`input`, `input + len(input)`]
+///
+/// USAGE:
+///    struct {i32 id; Str name} ParseInput(const char* i, const char** o) {
+///        const char* p = i; // create a new variable to pass the pointer
+///
+///        i32 id; Str name = StrInit();
+///        StrReadFmt(p, "Person id = {} and name = {}", id, name);
+///
+///        *o = p; // position after parsed input
+///    }
+///
 /// input[in]   : Input string to parse (must be null-terminated).
 /// fmtstr[in]  : Format string with `{}` placeholders (must be null-terminated).
 /// ...[in]     : Variable number of arguments that will receive the parsed values. Each
@@ -325,9 +347,12 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
     )
 #define StrReadFmt_IMPL2(input, fmtstr, varr)                                                                          \
     do {                                                                                                               \
-        TypeSpecificIO *argv_##__LINE__ = &(varr)[0];                                                                  \
-        size            argc_##__LINE__ = sizeof(varr) / sizeof(TypeSpecificIO);                                       \
-        StrReadFmtInternal((input), (fmtstr), argv_##__LINE__, argc_##__LINE__ - 1);                                   \
+        TypeSpecificIO *argv_##__LINE__     = &(varr)[0];                                                              \
+        char          **_p_input_##__LINE__ = (char **)(&(input));                                                     \
+        size            argc_##__LINE__     = sizeof(varr) / sizeof(TypeSpecificIO);                                   \
+        const char     *_input_##__LINE__ =                                                                            \
+            StrReadFmtInternal((const char *)*(_p_input_##__LINE__), (fmtstr), argv_##__LINE__, argc_##__LINE__ - 1);  \
+        (*_p_input_##__LINE__) = (char *)(_input_##__LINE__) ? (char *)(_input_##__LINE__) : (*_p_input_##__LINE__);   \
     } while (0)
 
 ///

--- a/Tests/Std/Io.Read.c
+++ b/Tests/Std/Io.Read.c
@@ -43,79 +43,98 @@ bool test_bitvec_reading(void);
 bool test_integer_decimal_reading(void) {
     WriteFmt("Testing integer decimal reading\n");
 
+    const char* z = NULL;
+
     bool success = true;
 
     // Test signed integers
     i8 i8_val = 0;
-    StrReadFmt("-42", "{}", i8_val);
+    z         = "-42";
+    StrReadFmt(z, "{}", i8_val);
     success = success && (i8_val == -42);
 
     i16 i16_val = 0;
-    StrReadFmt("-1234", "{}", i16_val);
+    z           = "-1234";
+    StrReadFmt(z, "{}", i16_val);
     success = success && (i16_val == -1234);
 
     i32 i32_val = 0;
-    StrReadFmt("-123456", "{}", i32_val);
+    z           = "-123456";
+    StrReadFmt(z, "{}", i32_val);
     success = success && (i32_val == -123456);
 
     i64 i64_val = 0;
-    StrReadFmt("-1234567890", "{}", i64_val);
+    z           = "-1234567890";
+    StrReadFmt(z, "{}", i64_val);
     success = success && (i64_val == -1234567890LL);
 
     // Test unsigned integers
     u8 u8_val = 0;
-    StrReadFmt("42", "{}", u8_val);
+    z         = "42";
+    StrReadFmt(z, "{}", u8_val);
     success = success && (u8_val == 42);
 
     u16 u16_val = 0;
-    StrReadFmt("1234", "{}", u16_val);
+    z           = "1234";
+    StrReadFmt(z, "{}", u16_val);
     success = success && (u16_val == 1234);
 
     u32 u32_val = 0;
-    StrReadFmt("123456", "{}", u32_val);
+    z           = "123456";
+    StrReadFmt(z, "{}", u32_val);
     success = success && (u32_val == 123456);
 
     u64 u64_val = 0;
-    StrReadFmt("1234567890", "{}", u64_val);
+    z           = "1234567890";
+    StrReadFmt(z, "{}", u64_val);
     success = success && (u64_val == 1234567890ULL);
 
     // Test edge cases
     i8_val = 0;
-    StrReadFmt("127", "{}", i8_val);
+    z      = "127";
+    StrReadFmt(z, "{}", i8_val);
     success = success && (i8_val == 127);
 
     i8_val = 0;
-    StrReadFmt("-128", "{}", i8_val);
+    z      = "-128";
+    StrReadFmt(z, "{}", i8_val);
     success = success && (i8_val == -128);
 
     u8_val = 0;
-    StrReadFmt("255", "{}", u8_val);
+    z      = "255";
+    StrReadFmt(z, "{}", u8_val);
     success = success && (u8_val == 255);
 
     u8_val = 0;
-    StrReadFmt("0", "{}", u8_val);
+    z      = "0";
+    StrReadFmt(z, "{}", u8_val);
     success = success && (u8_val == 0);
 
     // Test leading zeros
     i32_val = 0;
-    StrReadFmt("000042", "{}", i32_val);
+    z       = "000042";
+    StrReadFmt(z, "{}", i32_val);
     success = success && (i32_val == 42);
 
     i32_val = 0;
-    StrReadFmt("-000042", "{}", i32_val);
+    z       = "-000042";
+    StrReadFmt(z, "{}", i32_val);
     success = success && (i32_val == -42);
 
     // Test whitespace handling
     i32_val = 0;
-    StrReadFmt("   42", "{}", i32_val);
+    z       = "   42";
+    StrReadFmt(z, "{}", i32_val);
     success = success && (i32_val == 42);
 
     i32_val = 0;
-    StrReadFmt("42   ", "{}", i32_val);
+    z       = "42   ";
+    StrReadFmt(z, "{}", i32_val);
     success = success && (i32_val == 42);
 
     i32_val = 0;
-    StrReadFmt("  42  ", "{}", i32_val);
+    z       = "  42  ";
+    StrReadFmt(z, "{}", i32_val);
     success = success && (i32_val == 42);
 
     return success;
@@ -125,27 +144,34 @@ bool test_integer_decimal_reading(void) {
 bool test_integer_hex_reading(void) {
     WriteFmt("Testing integer hexadecimal reading\n");
 
+    const char* z = NULL;
+
     bool success = true;
 
     u32 val = 0;
-    StrReadFmt("0xdeadbeef", "{}", val);
+    z       = "0xdeadbeef";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 0xdeadbeef);
 
     val = 0;
-    StrReadFmt("0xDEADBEEF", "{}", val);
+    z   = "0xDEADBEEF";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 0xDEADBEEF);
 
     // Test hex edge cases
     val = 0;
-    StrReadFmt("0x0", "{}", val);
+    z   = "0x0";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 0);
 
     val = 0;
-    StrReadFmt("0xf", "{}", val);
+    z   = "0xf";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 0xf);
 
     val = 0;
-    StrReadFmt("0xaBcDeF", "{}", val);
+    z   = "0xaBcDeF";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 0xabcdef);
 
     return success;
@@ -155,19 +181,24 @@ bool test_integer_hex_reading(void) {
 bool test_integer_binary_reading(void) {
     WriteFmt("Testing integer binary reading\n");
 
+    const char* z = NULL;
+
     bool success = true;
 
     i8 val = 0;
-    StrReadFmt("0b101010", "{}", val);
+    z      = "0b101010";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 42);
 
     // Test binary edge cases
     val = 0;
-    StrReadFmt("0b0", "{}", val);
+    z   = "0b0";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 0);
 
     val = 0;
-    StrReadFmt("0b1", "{}", val);
+    z   = "0b1";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 1);
 
     return success;
@@ -177,23 +208,29 @@ bool test_integer_binary_reading(void) {
 bool test_integer_octal_reading(void) {
     WriteFmt("Testing integer octal reading\n");
 
+    const char* z = NULL;
+
     bool success = true;
 
     i32 val = 0;
-    StrReadFmt("0o755", "{}", val);
+    z       = "0o755";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 0755);
 
     val = 0;
-    StrReadFmt("755", "{}", val);
+    z   = "755";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 755);
 
     // Test octal edge cases
     val = 0;
-    StrReadFmt("0o0", "{}", val);
+    z   = "0o0";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 0);
 
     val = 0;
-    StrReadFmt("0o7", "{}", val);
+    z   = "0o7";
+    StrReadFmt(z, "{}", val);
     success = success && (val == 7);
 
     return success;
@@ -203,34 +240,42 @@ bool test_integer_octal_reading(void) {
 bool test_float_basic_reading(void) {
     WriteFmt("Testing basic float reading\n");
 
+    const char* z = NULL;
+
     bool success = true;
 
     // Test basic float values
     f32 f32_val = 0.0f;
-    StrReadFmt("3.14159", "{}", f32_val);
+    z           = "3.14159";
+    StrReadFmt(z, "{}", f32_val);
     success = success && float_equals(f32_val, 3.14159f);
 
     f64 f64_val = 0.0;
-    StrReadFmt("3.14159265359", "{}", f64_val);
+    z           = "3.14159265359";
+    StrReadFmt(z, "{}", f64_val);
     success = success && double_equals(f64_val, 3.14159265359);
 
     // Test float edge cases
     f64_val = 1.0;
-    StrReadFmt("0.0", "{}", f64_val);
+    z       = "0.0";
+    StrReadFmt(z, "{}", f64_val);
     success = success && double_equals(f64_val, 0.0);
 
     f64_val = 1.0;
-    StrReadFmt("-0.0", "{}", f64_val);
+    z       = "-0.0";
+    StrReadFmt(z, "{}", f64_val);
     // Special case for -0.0 which compares equal to 0.0 but has different bit pattern
     // We'll just check if it's close to zero
     success = success && double_equals(f64_val, 0.0);
 
     f64_val = 0.0;
-    StrReadFmt("42.0", "{}", f64_val);
+    z       = "42.0";
+    StrReadFmt(z, "{}", f64_val);
     success = success && double_equals(f64_val, 42.0);
 
     f64_val = 0.0;
-    StrReadFmt("0.42", "{}", f64_val);
+    z       = "0.42";
+    StrReadFmt(z, "{}", f64_val);
     success = success && double_equals(f64_val, 0.42);
 
     return success;
@@ -240,35 +285,44 @@ bool test_float_basic_reading(void) {
 bool test_float_scientific_reading(void) {
     WriteFmt("Testing scientific notation reading\n");
 
+    const char* z = NULL;
+
     bool success = true;
 
     f64 val = 0.0;
-    StrReadFmt("1.23e4", "{}", val);
+    z       = "1.23e4";
+    StrReadFmt(z, "{}", val);
     success = success && double_equals(val, 12300.0);
 
     val = 0.0;
-    StrReadFmt("1.23E4", "{}", val);
+    z   = "1.23E4";
+    StrReadFmt(z, "{}", val);
     success = success && double_equals(val, 12300.0);
 
     val = 0.0;
-    StrReadFmt("1.23e+4", "{}", val);
+    z   = "1.23e+4";
+    StrReadFmt(z, "{}", val);
     success = success && double_equals(val, 12300.0);
 
     val = 0.0;
-    StrReadFmt("1.23e-4", "{}", val);
+    z   = "1.23e-4";
+    StrReadFmt(z, "{}", val);
     success = success && double_equals(val, 0.000123);
 
     // Test scientific notation edge cases
     val = 0.0;
-    StrReadFmt("1.0e0", "{}", val);
+    z   = "1.0e0";
+    StrReadFmt(z, "{}", val);
     success = success && double_equals(val, 1.0);
 
     val = 0.0;
-    StrReadFmt("1.0E-0", "{}", val);
+    z   = "1.0E-0";
+    StrReadFmt(z, "{}", val);
     success = success && double_equals(val, 1.0);
 
     val = 0.0;
-    StrReadFmt("1.0e+0", "{}", val);
+    z   = "1.0e+0";
+    StrReadFmt(z, "{}", val);
     success = success && double_equals(val, 1.0);
 
     return success;
@@ -278,11 +332,14 @@ bool test_float_scientific_reading(void) {
 bool test_string_reading(void) {
     WriteFmt("Testing string reading\n");
 
+    const char* z = NULL;
+
     bool success = true;
 
     // Test basic string reading
     Str s = StrInit();
-    StrReadFmt("Hello", "{}", s);
+    z     = "Hello";
+    StrReadFmt(z, "{}", s);
 
     Str expected = StrInitFromZstr("Hello");
     success      = success && (StrCmp(&s, &expected) == 0);
@@ -290,7 +347,8 @@ bool test_string_reading(void) {
     StrClear(&s);
 
     // Test quoted string reading
-    StrReadFmt("\"Hello, World!\"", "{}", s);
+    z = "\"Hello, World!\"";
+    StrReadFmt(z, "{}", s);
 
     expected = StrInitFromZstr("Hello, World!");
     success  = success && (StrCmp(&s, &expected) == 0);
@@ -305,11 +363,14 @@ bool test_string_reading(void) {
 bool test_multiple_arguments_reading(void) {
     WriteFmt("Testing multiple arguments reading\n");
 
+    const char* z = NULL;
+
     bool success = true;
 
     i32 num  = 0;
     Str name = StrInit();
-    StrReadFmt("Count: 42, Name: Alice", "Count: {}, Name: {}", num, name);
+    z        = "Count: 42, Name: Alice";
+    StrReadFmt(z, "Count: {}, Name: {}", num, name);
 
     success = success && (num == 42);
 
@@ -320,7 +381,8 @@ bool test_multiple_arguments_reading(void) {
 
     // Test with different order
     f64 val = 0.0;
-    StrReadFmt("Value: 3.14, Name: Bob", "Value: {}, Name: {}", val, name);
+    z       = "Value: 3.14, Name: Bob";
+    StrReadFmt(z, "Value: {}, Name: {}", val, name);
 
     success = success && double_equals(val, 3.14);
 
@@ -337,6 +399,8 @@ bool test_multiple_arguments_reading(void) {
 bool test_error_handling_reading(void) {
     WriteFmt("Testing error handling for reading\n");
 
+    const char* z = NULL;
+
     // For error handling tests, we'll just verify that the variables don't change
     // when invalid input is provided
 
@@ -344,18 +408,20 @@ bool test_error_handling_reading(void) {
 
     // Test mismatched format
     i32 num = 42;
-    StrReadFmt("Count: forty-two", "Count: {}", num);
-    // The value should remain unchanged since the parsing should fail
+    z       = "Count: forty-two";
+    StrReadFmt(z, "Count: {}", num);
     success = success && (num == 42);
 
     // Test invalid integer
     num = 42;
-    StrReadFmt("Count: abc", "Count: {}", num);
+    z   = "Count: abc";
+    StrReadFmt(z, "Count: {}", num);
     success = success && (num == 42);
 
     // Test overflow
     i8 small = 42;
-    StrReadFmt("Value: 1000", "Value: {}", small);
+    z        = "Value: 1000";
+    StrReadFmt(z, "Value: {}", small);
     success = success && (small == 42);
 
     return success;
@@ -365,60 +431,71 @@ bool test_error_handling_reading(void) {
 bool test_character_ordinal_reading(void) {
     WriteFmt("Testing character ordinal reading with :c format specifier\n");
 
+    const char* z = NULL;
+
     bool success = true;
 
     // Test reading single character into u8
     u8 u8_val = 0;
-    StrReadFmt("A", "{c}", u8_val);
+    z         = "A";
+    StrReadFmt(z, "{c}", u8_val);
     WriteFmt("u8_val = {}, expected = {}, pass = {}\n", u8_val, 'A', (u8_val == 'A') ? "true" : "false");
     success = success && (u8_val == 'A');
 
     u8_val = 0;
-    StrReadFmt("z", "{c}", u8_val);
+    z      = "z";
+    StrReadFmt(z, "{c}", u8_val);
     WriteFmt("u8_val = {}, expected = {}, pass = {}\n", u8_val, 'z', (u8_val == 'z') ? "true" : "false");
     success = success && (u8_val == 'z');
 
     // Test reading single character into signed integers
     i8 i8_val = 0;
-    StrReadFmt("B", "{c}", i8_val);
+    z         = "B";
+    StrReadFmt(z, "{c}", i8_val);
     WriteFmt("i8_val = {}, expected = {}, pass = {}\n", i8_val, 'B', (i8_val == 'B') ? "true" : "false");
     success = success && (i8_val == 'B');
 
     i16 i16_val = 0;
-    StrReadFmt("C", "{c}", i16_val);
+    z           = "C";
+    StrReadFmt(z, "{c}", i16_val);
     WriteFmt("i16_val = {}, expected = {}, pass = {}\n", i16_val, 'C', (i16_val == 'C') ? "true" : "false");
     success = success && (i16_val == 'C');
 
     i32 i32_val = 0;
-    StrReadFmt("D", "{c}", i32_val);
+    z           = "D";
+    StrReadFmt(z, "{c}", i32_val);
     WriteFmt("i32_val = {}, expected = {}, pass = {}\n", i32_val, 'D', (i32_val == 'D') ? "true" : "false");
     success = success && (i32_val == 'D');
 
     i64 i64_val = 0;
-    StrReadFmt("E", "{c}", i64_val);
+    z           = "E";
+    StrReadFmt(z, "{c}", i64_val);
     WriteFmt("i64_val = {}, expected = {}, pass = {}\n", i64_val, 'E', (i64_val == 'E') ? "true" : "false");
     success = success && (i64_val == 'E');
 
     // Test reading single character into unsigned integers
     u16 u16_val = 0;
-    StrReadFmt("F", "{c}", u16_val);
+    z           = "F";
+    StrReadFmt(z, "{c}", u16_val);
     WriteFmt("u16_val = {}, expected = {}, pass = {}\n", u16_val, 'F', (u16_val == 'F') ? "true" : "false");
     success = success && (u16_val == 'F');
 
     u32 u32_val = 0;
-    StrReadFmt("G", "{c}", u32_val);
+    z           = "G";
+    StrReadFmt(z, "{c}", u32_val);
     WriteFmt("u32_val = {}, expected = {}, pass = {}\n", u32_val, 'G', (u32_val == 'G') ? "true" : "false");
     success = success && (u32_val == 'G');
 
     u64 u64_val = 0;
-    StrReadFmt("H", "{c}", u64_val);
+    z           = "H";
+    StrReadFmt(z, "{c}", u64_val);
     WriteFmt("u64_val = {}, expected = {}, pass = {}\n", u64_val, 'H', (u64_val == 'H') ? "true" : "false");
     success = success && (u64_val == 'H');
 
     // Test reading multiple characters into larger integer types
-    // For u16, read 2 characters
     u16_val = 0;
-    StrReadFmt("AB", "{c}", u16_val);
+    z       = "AB";
+    StrReadFmt(z, "{c}", u16_val);
     bool u16_multi_pass = (ZstrCompareN((const char*)&u16_val, "AB", 2) == 0);
     WriteFmt("u16_val multi-char test: comparing memory with 'AB', pass = {}\n", u16_multi_pass ? "true" : "false");
     WriteFmt(
@@ -430,30 +507,30 @@ bool test_character_ordinal_reading(void) {
     );
     success = success && u16_multi_pass;
 
-    // For i16, read 2 characters
     i16_val = 0;
-    StrReadFmt("CD", "{c}", i16_val);
+    z       = "CD";
+    StrReadFmt(z, "{c}", i16_val);
     bool i16_multi_pass = (ZstrCompareN((const char*)&i16_val, "CD", 2) == 0);
     WriteFmt("i16_val multi-char test: comparing memory with 'CD', pass = {}\n", i16_multi_pass ? "true" : "false");
     success = success && i16_multi_pass;
 
-    // For u32, read up to 4 characters
     u32_val = 0;
-    StrReadFmt("EFGH", "{c}", u32_val);
+    z       = "EFGH";
+    StrReadFmt(z, "{c}", u32_val);
     bool u32_multi_pass = (ZstrCompareN((const char*)&u32_val, "EFGH", 4) == 0);
     WriteFmt("u32_val multi-char test: comparing memory with 'EFGH', pass = {}\n", u32_multi_pass ? "true" : "false");
     success = success && u32_multi_pass;
 
-    // For i32, read up to 4 characters
     i32_val = 0;
-    StrReadFmt("IJKL", "{c}", i32_val);
+    z       = "IJKL";
+    StrReadFmt(z, "{c}", i32_val);
     bool i32_multi_pass = (ZstrCompareN((const char*)&i32_val, "IJKL", 4) == 0);
     WriteFmt("i32_val multi-char test: comparing memory with 'IJKL', pass = {}\n", i32_multi_pass ? "true" : "false");
     success = success && i32_multi_pass;
 
-    // For u64, read up to 8 characters
     u64_val = 0;
-    StrReadFmt("MNOPQRST", "{c}", u64_val);
+    z       = "MNOPQRST";
+    StrReadFmt(z, "{c}", u64_val);
     bool u64_multi_pass = (ZstrCompareN((const char*)&u64_val, "MNOPQRST", 8) == 0);
     WriteFmt(
         "u64_val multi-char test: comparing memory with 'MNOPQRST', pass = {}\n",
@@ -461,9 +538,9 @@ bool test_character_ordinal_reading(void) {
     );
     success = success && u64_multi_pass;
 
-    // For i64, read up to 8 characters
     i64_val = 0;
-    StrReadFmt("UVWXYZab", "{c}", i64_val);
+    z       = "UVWXYZab";
+    StrReadFmt(z, "{c}", i64_val);
     bool i64_multi_pass = (ZstrCompareN((const char*)&i64_val, "UVWXYZab", 8) == 0);
     WriteFmt(
         "i64_val multi-char test: comparing memory with 'UVWXYZab', pass = {}\n",
@@ -471,43 +548,44 @@ bool test_character_ordinal_reading(void) {
     );
     success = success && i64_multi_pass;
 
-    // Test reading characters into float types (should interpret as character ordinals)
     f32 f32_val = 0.0f;
-    StrReadFmt("A", "{c}", f32_val);
+    z           = "A";
+    StrReadFmt(z, "{c}", f32_val);
     bool f32_pass = (f32_val == (f32)'A');
     WriteFmt("f32_val = {}, expected = {}, pass = {}\n", f32_val, (f32)'A', f32_pass ? "true" : "false");
     success = success && f32_pass;
 
     f64 f64_val = 0.0;
-    StrReadFmt("B", "{c}", f64_val);
+    z           = "B";
+    StrReadFmt(z, "{c}", f64_val);
     bool f64_pass = (f64_val == (f64)'B');
     WriteFmt("f64_val = {}, expected = {}, pass = {}\n", f64_val, (f64)'B', f64_pass ? "true" : "false");
     success = success && f64_pass;
 
-    // Test with high ASCII characters
     u8_val = 0;
-    StrReadFmt("~", "{c}", u8_val);
+    z      = "~";
+    StrReadFmt(z, "{c}", u8_val);
     bool tilde_pass = (u8_val == '~');
     WriteFmt("u8_val = {}, expected = {} (~), pass = {}\n", u8_val, '~', tilde_pass ? "true" : "false");
     success = success && tilde_pass;
 
-    // Test partial reads for larger types with fewer characters
     u32_val = 0;
-    StrReadFmt("XY", "{c}", u32_val);
+    z       = "XY";
+    StrReadFmt(z, "{c}", u32_val);
     bool xy_pass = (ZstrCompareN((const char*)&u32_val, "XY", 2) == 0);
     WriteFmt("u32_val partial test: comparing memory with 'XY', pass = {}\n", xy_pass ? "true" : "false");
     success = success && xy_pass;
 
     u64_val = 0;
-    StrReadFmt("abc", "{c}", u64_val);
+    z       = "abc";
+    StrReadFmt(z, "{c}", u64_val);
     bool abc_pass = (ZstrCompareN((const char*)&u64_val, "abc", 3) == 0);
     WriteFmt("u64_val partial test: comparing memory with 'abc', pass = {}\n", abc_pass ? "true" : "false");
     success = success && abc_pass;
 
-    // Test that :c has no effect on string types (should work like regular string reading)
     Str str_val = StrInit();
-    StrReadFmt("Hello", "{c}", str_val);
-
+    z           = "Hello";
+    StrReadFmt(z, "{c}", str_val);
     Str  expected = StrInitFromZstr("Hello");
     bool str_pass = (StrCmp(&str_val, &expected) == 0);
     WriteFmt("str_val test: comparing with 'Hello', pass = {}\n", str_pass ? "true" : "false");
@@ -515,10 +593,9 @@ bool test_character_ordinal_reading(void) {
     StrDeinit(&expected);
     StrDeinit(&str_val);
 
-    // Test :c with quoted strings (should work like regular string reading)
     str_val = StrInit();
-    StrReadFmt("\"World\"", "{c}", str_val);
-
+    z       = "\"World\"";
+    StrReadFmt(z, "{c}", str_val);
     expected             = StrInitFromZstr("World");
     bool quoted_str_pass = (StrCmp(&str_val, &expected) == 0);
     WriteFmt("quoted str_val test: comparing with 'World', pass = {}\n", quoted_str_pass ? "true" : "false");
@@ -534,17 +611,19 @@ bool test_character_ordinal_reading(void) {
 bool test_string_case_conversion_reading(void) {
     WriteFmt("Testing string case conversion with :a and :A format specifiers\n");
 
+    const char* z = NULL;
+
     bool success = true;
 
     // Test 1: :a (lowercase) conversion
     {
-        Str         result = StrInit();
-        const char* input  = "Hello World";
+        Str result = StrInit();
+        z          = "Hello World";
 
-        StrReadFmt(input, "{a}", result);
+        StrReadFmt(z, "{a}", result);
 
         WriteFmt("Test 1 - :a (lowercase)\n");
-        WriteFmt("Input: '{}', Output: '", input);
+        WriteFmt("Input: '{}', Output: '", z);
         for (size_t i = 0; i < result.length; i++) {
             WriteFmt("{c}", result.data[i]);
         }
@@ -562,13 +641,13 @@ bool test_string_case_conversion_reading(void) {
 
     // Test 2: :A (uppercase) conversion
     {
-        Str         result = StrInit();
-        const char* input  = "hello world";
+        Str result = StrInit();
+        z          = "hello world";
 
-        StrReadFmt(input, "{A}", result);
+        StrReadFmt(z, "{A}", result);
 
         WriteFmt("Test 2 - :A (uppercase)\n");
-        WriteFmt("Input: '{}', Output: '", input);
+        WriteFmt("Input: '{}', Output: '", z);
         for (size_t i = 0; i < result.length; i++) {
             WriteFmt("{c}", result.data[i]);
         }
@@ -586,13 +665,13 @@ bool test_string_case_conversion_reading(void) {
 
     // Test 3: :a with quoted string
     {
-        Str         result = StrInit();
-        const char* input  = "\"MiXeD CaSe\"";
+        Str result = StrInit();
+        z          = "\"MiXeD CaSe\"";
 
-        StrReadFmt(input, "{a}", result);
+        StrReadFmt(z, "{a}", result);
 
         WriteFmt("Test 3 - :a with quoted string\n");
-        WriteFmt("Input: '{}', Output: '", input);
+        WriteFmt("Input: '{}', Output: '", z);
         for (size_t i = 0; i < result.length; i++) {
             WriteFmt("{c}", result.data[i]);
         }
@@ -610,13 +689,13 @@ bool test_string_case_conversion_reading(void) {
 
     // Test 4: :A with quoted string containing special characters
     {
-        Str         result = StrInit();
-        const char* input  = "\"abc123XYZ\"";
+        Str result = StrInit();
+        z          = "\"abc123XYZ\"";
 
-        StrReadFmt(input, "{A}", result);
+        StrReadFmt(z, "{A}", result);
 
         WriteFmt("Test 4 - :A with mixed alphanumeric\n");
-        WriteFmt("Input: '{}', Output: '", input);
+        WriteFmt("Input: '{}', Output: '", z);
         for (size_t i = 0; i < result.length; i++) {
             WriteFmt("{c}", result.data[i]);
         }
@@ -634,13 +713,13 @@ bool test_string_case_conversion_reading(void) {
 
     // Test 5: Regular :c format (no case conversion) for comparison
     {
-        Str         result = StrInit();
-        const char* input  = "Hello World";
+        Str result = StrInit();
+        z          = "Hello World";
 
-        StrReadFmt(input, "{c}", result);
+        StrReadFmt(z, "{c}", result);
 
         WriteFmt("Test 5 - :c (no case conversion)\n");
-        WriteFmt("Input: '{}', Output: '", input);
+        WriteFmt("Input: '{}', Output: '", z);
         for (size_t i = 0; i < result.length; i++) {
             WriteFmt("{c}", result.data[i]);
         }
@@ -664,11 +743,14 @@ bool test_string_case_conversion_reading(void) {
 bool test_bitvec_reading(void) {
     WriteFmt("Testing BitVec reading\n");
 
+    const char* z = NULL;
+
     bool success = true;
 
     // Test 1: Reading binary string
     BitVec bv1 = BitVecInit();
-    StrReadFmt("10110", "{}", bv1);
+    z          = "10110";
+    StrReadFmt(z, "{}", bv1);
     Str result1 = BitVecToStr(&bv1);
     success     = success && (ZstrCompare(result1.data, "10110") == 0);
     WriteFmt(
@@ -681,7 +763,8 @@ bool test_bitvec_reading(void) {
 
     // Test 2: Reading hex format
     BitVec bv2 = BitVecInit();
-    StrReadFmt("0xDEAD", "{}", bv2);
+    z          = "0xDEAD";
+    StrReadFmt(z, "{}", bv2);
     u64 value2 = BitVecToInteger(&bv2);
     success    = success && (value2 == 0xDEAD);
     WriteFmt("Test 2 - Hex: {}, Success: {}\n", value2, (value2 == 0xDEAD) ? "true" : "false");
@@ -689,7 +772,8 @@ bool test_bitvec_reading(void) {
 
     // Test 3: Reading octal format
     BitVec bv3 = BitVecInit();
-    StrReadFmt("0o755", "{}", bv3);
+    z          = "0o755";
+    StrReadFmt(z, "{}", bv3);
     u64 value3 = BitVecToInteger(&bv3);
     success    = success && (value3 == 0755);
     WriteFmt("Test 3 - Octal: {}, Success: {}\n", value3, (value3 == 0755) ? "true" : "false");
@@ -697,7 +781,8 @@ bool test_bitvec_reading(void) {
 
     // Test 4: Reading with whitespace
     BitVec bv4 = BitVecInit();
-    StrReadFmt("   1101", "{}", bv4);
+    z          = "   1101";
+    StrReadFmt(z, "{}", bv4);
     Str result4 = BitVecToStr(&bv4);
     success     = success && (ZstrCompare(result4.data, "1101") == 0);
     WriteFmt(
@@ -710,7 +795,8 @@ bool test_bitvec_reading(void) {
 
     // Test 5: Reading zero values
     BitVec bv5 = BitVecInit();
-    StrReadFmt("0", "{}", bv5);
+    z          = "0";
+    StrReadFmt(z, "{}", bv5);
     Str result5 = BitVecToStr(&bv5);
     success     = success && (ZstrCompare(result5.data, "0") == 0);
     WriteFmt("Test 5 - Zero: {}, Success: {}\n", result5, (ZstrCompare(result5.data, "0") == 0) ? "true" : "false");


### PR DESCRIPTION
Earlier `StrReadFmt` will just read from given `input` (in first parameter) and leave it untouched. This is a bit inconvenient when dealing with a long string where input must be processed in parts to understand what's coming next. To make this easier, we now mandate the first parameter to be an assignable `l-value` that `StrReadFmt` will automatically update to a value between [`input`, `input + len(input)`] so next call continues from previous parsed position instead of always starting from the beginning.

There can be other solutions to this, but this is the one that I find easy to implement right now, with least modification to current code and tests and with with we want getting done.

There are few caveats now of using `StrReadFmt`, like not using an `l-value` is undefined behavior. A segfault is the best thing that could happen in this case.