### PR TITLE
New fmt spec

### DIFF
--- a/Include/Misra/Std/Io.h
+++ b/Include/Misra/Std/Io.h
@@ -49,6 +49,7 @@ typedef enum {
 /// FMT_FLAG_FORCE_CASE    : Force case conversion (used with FMT_FLAG_CAPS)
 /// FMT_FLAG_HAS_PRECISION : Precision was specified in format string.
 /// FMT_FLAG_RAW           : Read/write data in raw binary format
+/// FMT_FLAG_STRING        : Read a single word, a quoted string (single or double quoted)
 ///
 /// TAGS: Formatting, Text, Flags
 typedef enum {
@@ -61,7 +62,8 @@ typedef enum {
     FMT_FLAG_CAPS          = 1 << 5,
     FMT_FLAG_FORCE_CASE    = 1 << 6,
     FMT_FLAG_HAS_PRECISION = 1 << 7,
-    FMT_FLAG_RAW           = 1 << 8
+    FMT_FLAG_RAW           = 1 << 8,
+    FMT_FLAG_STRING        = 1 << 9,
 } FormatFlagsBits;
 typedef u32 FormatFlags;
 
@@ -268,6 +270,7 @@ void FReadFmtInternal(FILE *stream, const char *fmtstr, TypeSpecificIO *argv, si
 ///       or `StrWriteFmt(o, "{}", 1337)` for integer literals might not work as expected
 ///       without proper wrapping using ``. For constants like integers, booleans,
 ///       you typically use `constant_variable`.
+/// NOTE: New content is appended at the end of given Str object.
 ///
 /// out[out]    : The Str object to which the formatted string will be appended.
 /// fmtstr[in]  : Format string with `{}` placeholders.

--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ Specifies the output format for the value:
 | `r` | Raw data reading or writing | `\x7fELF` (magic bytes of an elf file) |
 | `e` | Scientific notation (lowercase) | `1.235e+02` |
 | `E` | Scientific notation (uppercase) | `1.235E+02` |
+| `s` | Read a string in single quotes or double quotes, or a single word | `"this is a string"`, `'this as well'`, `this not a string` |
 
 #### Precision
 

--- a/Source/Misra/Std/Io.c
+++ b/Source/Misra/Std/Io.c
@@ -125,7 +125,7 @@ static bool ParseFormatSpec(const char* spec, u32 len, FmtInfo* fi) {
     }
 
     // Parse format type after precision
-    if (pos < len) {
+    while (pos < len) {
         switch (spec[pos]) {
             case 'c' :
                 fi->flags |= FMT_FLAG_CHAR;

--- a/Source/Misra/Std/Io.c
+++ b/Source/Misra/Std/Io.c
@@ -163,6 +163,10 @@ static bool ParseFormatSpec(const char* spec, u32 len, FmtInfo* fi) {
                 fi->flags |= FMT_FLAG_SCIENTIFIC;
                 break;
 
+            case 's' :
+                fi->flags |= FMT_FLAG_STRING;
+                break;
+
             default :
                 LOG_ERROR("Invalid format specifier");
                 return false;
@@ -562,6 +566,9 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
             remaining--;
         } else {
             // Match exact character from format string
+            if (*in == '\r' || *in == '\n') {
+                LOG_INFO("Skipping CRLF");
+            }
             if (!in || *in != *p) {
                 LOG_ERROR(
                     "Input '{.8}' does not match format string '{.8}'",
@@ -569,6 +576,9 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
                     LVAL(p ? p : "(null)")
                 );
                 return NULL;
+            }
+            if (*in == '\r' || *in == '\n') {
+                LOG_INFO("Skipped CRLF");
             }
             in++;
             p++;
@@ -1254,6 +1264,7 @@ const char* _read_Str(const char* i, FmtInfo* fmt_info, Str* s) {
     // Check for case conversion flags
     bool force_case = fmt_info && (fmt_info->flags & FMT_FLAG_FORCE_CASE) != 0;
     bool is_caps    = fmt_info && (fmt_info->flags & FMT_FLAG_CAPS) != 0;
+    bool is_string  = fmt_info && (fmt_info->flags & FMT_FLAG_STRING) != 0;
 
     // Skip leading whitespace
     while (IS_SPACE(*i))
@@ -1267,7 +1278,7 @@ const char* _read_Str(const char* i, FmtInfo* fmt_info, Str* s) {
 
     // Check for quoted string
     char quote = 0;
-    if (*i == '"' || *i == '\'') {
+    if (is_string && (*i == '"' || *i == '\'')) {
         quote = *i++;
     }
 

--- a/Source/Misra/Std/Io.c
+++ b/Source/Misra/Std/Io.c
@@ -566,9 +566,6 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
             remaining--;
         } else {
             // Match exact character from format string
-            if (*in == '\r' || *in == '\n') {
-                LOG_INFO("Skipping CRLF");
-            }
             if (!in || *in != *p) {
                 LOG_ERROR(
                     "Input '{.8}' does not match format string '{.8}'",
@@ -576,9 +573,6 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
                     LVAL(p ? p : "(null)")
                 );
                 return NULL;
-            }
-            if (*in == '\r' || *in == '\n') {
-                LOG_INFO("Skipped CRLF");
             }
             in++;
             p++;

--- a/Tests/Std/Io.Read.c
+++ b/Tests/Std/Io.Read.c
@@ -348,7 +348,7 @@ bool test_string_reading(void) {
 
     // Test quoted string reading
     z = "\"Hello, World!\"";
-    StrReadFmt(z, "{}", s);
+    StrReadFmt(z, "{s}", s);
 
     expected = StrInitFromZstr("Hello, World!");
     success  = success && (StrCmp(&s, &expected) == 0);
@@ -595,7 +595,7 @@ bool test_character_ordinal_reading(void) {
 
     str_val = StrInit();
     z       = "\"World\"";
-    StrReadFmt(z, "{c}", str_val);
+    StrReadFmt(z, "{cs}", str_val);
     expected             = StrInitFromZstr("World");
     bool quoted_str_pass = (StrCmp(&str_val, &expected) == 0);
     WriteFmt("quoted str_val test: comparing with 'World', pass = {}\n", quoted_str_pass ? "true" : "false");
@@ -668,7 +668,7 @@ bool test_string_case_conversion_reading(void) {
         Str result = StrInit();
         z          = "\"MiXeD CaSe\"";
 
-        StrReadFmt(z, "{a}", result);
+        StrReadFmt(z, "{as}", result);
 
         WriteFmt("Test 3 - :a with quoted string\n");
         WriteFmt("Input: '{}', Output: '", z);
@@ -692,7 +692,7 @@ bool test_string_case_conversion_reading(void) {
         Str result = StrInit();
         z          = "\"abc123XYZ\"";
 
-        StrReadFmt(z, "{A}", result);
+        StrReadFmt(z, "{As}", result);
 
         WriteFmt("Test 4 - :A with mixed alphanumeric\n");
         WriteFmt("Input: '{}', Output: '", z);


### PR DESCRIPTION
Previously, `Fmt` readers would automatically parse anything between `""` (double quotes) or `''` (single quotes) as a single string. Now there's a separate format specifier enable this. By default this mode is off. Meaning it'll only scan one single word at a time.

This means if this mode is off (by default which is), `"misra std c"` will be parsed as `"misra` if format specifier is "{}" to parse a single string only. But if the format specifier is `{s}`, then the parsed string will be `misra std c` as a single string.