### PR TITLE
Improved Formatted Reading

### DIFF
--- a/Include/Misra/Std/Io.h
+++ b/Include/Misra/Std/Io.h
@@ -84,6 +84,7 @@ typedef struct {
     u32         width; /// Alignment width or raw read/write size
     u32         precision;
     FormatFlags flags;
+    u32         max_read_len;
 } FmtInfo;
 
 ///

--- a/Source/Misra/Std/Io.c
+++ b/Source/Misra/Std/Io.c
@@ -403,40 +403,41 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
 
     const char* p         = fmtstr;
     const char* in        = input;
-    size        remaining = ZstrLen(fmtstr);
-    size        arg_index = 0; // Current argument index
+    u64         rem_p     = ZstrLen(fmtstr);
+    u64         rem_in    = ZstrLen(in);
+    u64         arg_index = 0; // Current argument index
 
-    while (remaining > 0) {
-        if (remaining >= 2 && p[0] == '{' && p[1] == '{') {
+    while (rem_p > 0) {
+        if (rem_p >= 2 && p[0] == '{' && p[1] == '{') {
             if (!in || *in != '{') {
                 LOG_ERROR("Expected '{' in input");
                 return NULL;
             }
             in++;
-            p         += 2;
-            remaining -= 2;
-        } else if (remaining >= 2 && p[0] == '}' && p[1] == '}') {
+            p     += 2;
+            rem_p -= 2;
+        } else if (rem_p >= 2 && p[0] == '}' && p[1] == '}') {
             if (!in || *in != '}') {
                 LOG_ERROR("Expected '}' in input");
                 return NULL;
             }
             in++;
-            p         += 2;
-            remaining -= 2;
+            p     += 2;
+            rem_p -= 2;
         } else if (p[0] == '{') {
             p++;
-            remaining--;
+            rem_p--;
 
             // Find closing brace
             const char* start    = p;
             size        spec_len = 0;
-            while (remaining > 0 && *p != '}') {
+            while (rem_p > 0 && *p != '}') {
                 p++;
-                remaining--;
+                rem_p--;
                 spec_len++;
             }
 
-            if (remaining == 0 || *p != '}') {
+            if (rem_p == 0 || *p != '}') {
                 LOG_ERROR("Unmatched '{' in format string");
                 return NULL;
             }
@@ -457,11 +458,16 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
             spec_buf[spec_len] = '\0';
 
             // Validate format specifier
-            FmtInfo fmt_info;
+            FmtInfo fmt_info = {0};
             if (!ParseFormatSpec(spec_buf, spec_len, &fmt_info)) {
                 LOG_ERROR("Failed to parse format specifier");
                 return NULL; // Error already logged by ParseFormatSpec
             }
+            fmt_info.max_read_len = rem_in;
+
+            // Skip closing '}'
+            p++;
+            rem_p--;
 
             // Use the type-specific reader
             TypeSpecificIO* io = &argv[arg_index++];
@@ -500,6 +506,10 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
                 // do raw read
                 u64 x = 0;
                 next  = raw_reader(in, &fmt_info, &x);
+
+                if (next) {
+                    rem_in -= (next - in);
+                }
 
                 // deduce the actual field size
                 u32   var_width = 0;
@@ -548,8 +558,37 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
                     }
                 }
             } else {
+                // find length between two format specifiers
+                u64  space_len = 0;
+                char c         = p[space_len];
+                while (c) {
+                    // if this is possible start of a new format specifier and not '{{' (escaped brace)
+                    if (c == '{' && p[space_len + 1] != '{') {
+                        break;
+                    } else {
+                        space_len++;
+                    }
+                    c = p[space_len];
+                }
+
+                // if there's something between two format specifiers then we can read only upto that
+                // otherwise end of input is the limit
+                if (space_len) {
+                    // Find first occurence of content between current and next format specifier or null character
+                    const char* e = NULL;
+                    if ((e = ZstrFindSubstringN(in, p, space_len))) {
+                        fmt_info.max_read_len = e - in;
+                    }
+                } else {
+                    fmt_info.max_read_len = rem_in;
+                }
+
                 // do formatted read
                 next = io->reader(in, &fmt_info, io->data);
+
+                if (next) {
+                    rem_in -= (next - in);
+                }
             }
 
             // Check if reading failed
@@ -560,10 +599,6 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
 
             // Update input pointer
             in = next;
-
-            // Skip closing '}'
-            p++;
-            remaining--;
         } else {
             // Match exact character from format string
             if (!in || *in != *p) {
@@ -576,7 +611,8 @@ const char* StrReadFmtInternal(const char* input, const char* fmtstr, TypeSpecif
             }
             in++;
             p++;
-            remaining--;
+            rem_p--;
+            rem_in--;
         }
     }
 
@@ -1259,10 +1295,7 @@ const char* _read_Str(const char* i, FmtInfo* fmt_info, Str* s) {
     bool force_case = fmt_info && (fmt_info->flags & FMT_FLAG_FORCE_CASE) != 0;
     bool is_caps    = fmt_info && (fmt_info->flags & FMT_FLAG_CAPS) != 0;
     bool is_string  = fmt_info && (fmt_info->flags & FMT_FLAG_STRING) != 0;
-
-    // Skip leading whitespace
-    while (IS_SPACE(*i))
-        i++;
+    u32  r          = fmt_info->max_read_len;
 
     // Check for empty input
     if (!*i) {
@@ -1274,9 +1307,10 @@ const char* _read_Str(const char* i, FmtInfo* fmt_info, Str* s) {
     char quote = 0;
     if (is_string && (*i == '"' || *i == '\'')) {
         quote = *i++;
+        r--;
     }
 
-    while (*i) {
+    while (r && *i) {
         if (quote) {
             // Quoted string mode
             if (*i == '\\') {
@@ -1286,7 +1320,8 @@ const char* _read_Str(const char* i, FmtInfo* fmt_info, Str* s) {
                     StrDeinit(s);
                     return NULL;
                 }
-                i = curr + 1; // Move past the escape sequence
+                i  = curr + 1; // Move past the escape sequence
+                r -= 2;
 
                 // Apply case conversion if needed
                 if (force_case) {
@@ -1296,9 +1331,11 @@ const char* _read_Str(const char* i, FmtInfo* fmt_info, Str* s) {
                 StrPushBack(s, c);
             } else if (*i == quote) {
                 i++;      // Skip closing quote
+                r--;
                 return i; // Successfully read quoted string
             } else {
                 char c = *i++;
+                r--;
 
                 // Apply case conversion if needed
                 if (force_case) {
@@ -1309,7 +1346,7 @@ const char* _read_Str(const char* i, FmtInfo* fmt_info, Str* s) {
             }
         } else {
             // Unquoted string mode - read until whitespace
-            if (IS_SPACE(*i)) {
+            if (is_string && IS_SPACE(*i)) {
                 return i; // Successfully read unquoted string
             }
 
@@ -1320,7 +1357,8 @@ const char* _read_Str(const char* i, FmtInfo* fmt_info, Str* s) {
                     StrDeinit(s);
                     return NULL;
                 }
-                i = curr + 1; // Move past the escape sequence
+                i  = curr + 1; // Move past the escape sequence
+                r -= 2;
 
                 // Apply case conversion if needed
                 if (force_case) {
@@ -1330,6 +1368,7 @@ const char* _read_Str(const char* i, FmtInfo* fmt_info, Str* s) {
                 StrPushBack(s, c);
             } else {
                 char c = *i++;
+                r--;
 
                 // Apply case conversion if needed
                 if (force_case) {

--- a/Tests/Std/Io.Read.c
+++ b/Tests/Std/Io.Read.c
@@ -617,13 +617,39 @@ bool test_string_case_conversion_reading(void) {
 
     // Test 1: :a (lowercase) conversion
     {
-        Str result = StrInit();
-        z          = "Hello World";
+        Str         result = StrInit();
+        const char* in     = "Hello World";
 
+        z = in;
         StrReadFmt(z, "{a}", result);
 
         WriteFmt("Test 1 - :a (lowercase)\n");
-        WriteFmt("Input: '{}', Output: '", z);
+        WriteFmt("Input: '{}', Output: '", in);
+        for (size_t i = 0; i < result.length; i++) {
+            WriteFmt("{c}", result.data[i]);
+        }
+        WriteFmt("'\n");
+
+        // Should read "hello" (stops at first space)
+        Str  expected   = StrInitFromZstr("hello world");
+        bool test1_pass = (StrCmp(&result, &expected) == 0);
+        WriteFmt("Expected: 'hello', Pass: {}\n\n", test1_pass ? "true" : "false");
+        success = success && test1_pass;
+
+        StrDeinit(&expected);
+        StrDeinit(&result);
+    }
+
+    // Test 1.1: :a (lowercase) conversion
+    {
+        Str         result = StrInit();
+        const char* in     = "Hello World";
+
+        z = in;
+        StrReadFmt(z, "{as}", result);
+
+        WriteFmt("Test 1.1 - :as (lowercase string single word)\n");
+        WriteFmt("Input: '{}', Output: '", in);
         for (size_t i = 0; i < result.length; i++) {
             WriteFmt("{c}", result.data[i]);
         }
@@ -641,20 +667,21 @@ bool test_string_case_conversion_reading(void) {
 
     // Test 2: :A (uppercase) conversion
     {
-        Str result = StrInit();
-        z          = "hello world";
+        Str         result = StrInit();
+        const char* in     = "hello world";
 
+        z = in;
         StrReadFmt(z, "{A}", result);
 
         WriteFmt("Test 2 - :A (uppercase)\n");
-        WriteFmt("Input: '{}', Output: '", z);
+        WriteFmt("Input: '{}', Output: '", in);
         for (size_t i = 0; i < result.length; i++) {
             WriteFmt("{c}", result.data[i]);
         }
         WriteFmt("'\n");
 
         // Should read "HELLO" (stops at first space)
-        Str  expected   = StrInitFromZstr("HELLO");
+        Str  expected   = StrInitFromZstr("HELLO WORLD");
         bool test2_pass = (StrCmp(&result, &expected) == 0);
         WriteFmt("Expected: 'HELLO', Pass: {}\n\n", test2_pass ? "true" : "false");
         success = success && test2_pass;
@@ -663,15 +690,60 @@ bool test_string_case_conversion_reading(void) {
         StrDeinit(&result);
     }
 
+    // Test 2.1: :A (uppercase) conversion
+    {
+        Str         result1 = StrInit();
+        Str         result2 = StrInit();
+        const char* in      = "hello world";
+
+        z = in;
+        StrReadFmt(z, "{A} {A}", result1, result2);
+
+        WriteFmt("Test 2 - :A (uppercase with split format)\n");
+        WriteFmt("Input: '{}', Output: '{} {}'", in, result1, result2);
+
+        bool test2_pass  = (StrCmpZstr(&result1, "HELLO") == 0);
+        test2_pass      &= (StrCmpZstr(&result2, "WORLD") == 0);
+        WriteFmt("Expected: 'HELLO WORLD', Pass: {}\n\n", test2_pass ? "true" : "false");
+        success = success && test2_pass;
+
+        StrDeinit(&result1);
+        StrDeinit(&result2);
+    }
+
+    // Test 2.2: :A (uppercase) conversion
+    {
+        Str         result1 = StrInit();
+        Str         result2 = StrInit();
+        const char* in      = "hello world mighty misra";
+
+        z = in;
+        StrReadFmt(z, "{As}{A}", result1, result2);
+        // result1 must consume first word only
+        // result2 must consume the space after hello and then everything after it
+
+        WriteFmt("Test 2 - :A (uppercase with split format)\n");
+        WriteFmt("Input: '{}', Output: '{}{}'", in, result1, result2);
+
+        bool test2_pass  = (StrCmpZstr(&result1, "HELLO") == 0);
+        test2_pass      &= (StrCmpZstr(&result2, " WORLD MIGHTY MISRA") == 0); // notice the extra space
+        WriteFmt("Expected: 'HELLO WORLD MIGHTY MISRA', Pass: {}\n\n", test2_pass ? "true" : "false");
+        success = success && test2_pass;
+
+        StrDeinit(&result1);
+        StrDeinit(&result2);
+    }
+
     // Test 3: :a with quoted string
     {
-        Str result = StrInit();
-        z          = "\"MiXeD CaSe\"";
+        Str         result = StrInit();
+        const char* in     = "\"MiXeD CaSe\"";
 
+        z = in;
         StrReadFmt(z, "{as}", result);
 
         WriteFmt("Test 3 - :a with quoted string\n");
-        WriteFmt("Input: '{}', Output: '", z);
+        WriteFmt("Input: '{}', Output: '", in);
         for (size_t i = 0; i < result.length; i++) {
             WriteFmt("{c}", result.data[i]);
         }
@@ -689,13 +761,14 @@ bool test_string_case_conversion_reading(void) {
 
     // Test 4: :A with quoted string containing special characters
     {
-        Str result = StrInit();
-        z          = "\"abc123XYZ\"";
+        Str         result = StrInit();
+        const char* in     = "\"abc123XYZ\"";
 
+        z = in;
         StrReadFmt(z, "{As}", result);
 
         WriteFmt("Test 4 - :A with mixed alphanumeric\n");
-        WriteFmt("Input: '{}', Output: '", z);
+        WriteFmt("Input: '{}', Output: '", in);
         for (size_t i = 0; i < result.length; i++) {
             WriteFmt("{c}", result.data[i]);
         }
@@ -713,22 +786,23 @@ bool test_string_case_conversion_reading(void) {
 
     // Test 5: Regular :c format (no case conversion) for comparison
     {
-        Str result = StrInit();
-        z          = "Hello World";
+        Str         result = StrInit();
+        const char* in     = "Hello World";
 
+        z = in;
         StrReadFmt(z, "{c}", result);
 
         WriteFmt("Test 5 - :c (no case conversion)\n");
-        WriteFmt("Input: '{}', Output: '", z);
+        WriteFmt("Input: '{}', Output: '", in);
         for (size_t i = 0; i < result.length; i++) {
             WriteFmt("{c}", result.data[i]);
         }
         WriteFmt("'\n");
 
         // Should read "Hello" (stops at first space, no case conversion)
-        Str  expected   = StrInitFromZstr("Hello");
+        Str  expected   = StrInitFromZstr("Hello World");
         bool test5_pass = (StrCmp(&result, &expected) == 0);
-        WriteFmt("Expected: 'Hello', Pass: {}\n\n", test5_pass ? "true" : "false");
+        WriteFmt("Expected: 'Hello World', Pass: {}\n\n", test5_pass ? "true" : "false");
         success = success && test5_pass;
 
         StrDeinit(&expected);


### PR DESCRIPTION
Formatted reading now better detects the length of content to be parsed. Before attempting to read value at a placeholder, it'll first find the maximum possible length of reading that. This works by the following logic :

- If there are two placeholders, and nothing is between them, the first placeholder can read as much as possible, and second placeholder may get empty!
- If there are two placeholders, and there's something in between them, first placeholder can only read up until the content between the space between the placeholders. So for `{} {}`, first placeholder can only read up until first space. Then rest becomes possible read length of second placeholder.
- If there is only one placeholder, it'll get to read the whole string. It may or may not read it completely.

This new logic makes fmt reading much more helpful and easy to work with. This means more string format checking when parsing input. Pair this with the new format specifier `{s}` in last PR #22, it makes it easier to parse strings, and formatted strings!