### PR TITLE
fix: guard vector byte-count multiplications against size overflow

### DIFF
--- a/Source/Misra/Std/Container/Vec.c
+++ b/Source/Misra/Std/Container/Vec.c
@@ -195,7 +195,7 @@ bool insert_range_into_vec(GenericVec *vec, const char *item_data, size item_siz
     }
 
     aligned_size = vec_aligned_size(vec, item_size);
-    if (count != 0 && aligned_size > SIZE_MAX / count) {
+    if (aligned_size > SIZE_MAX / count) {
         return false;
     }
     if (vec->length + count >= vec->capacity) {
@@ -260,7 +260,7 @@ bool insert_range_fast_into_vec(GenericVec *vec, const char *item_data, size ite
     }
 
     aligned_size = vec_aligned_size(vec, item_size);
-    if (count != 0 && aligned_size > SIZE_MAX / count) {
+    if (aligned_size > SIZE_MAX / count) {
         return false;
     }
     if (vec->length + count >= vec->capacity) {

--- a/Source/Misra/Std/Container/Vec.c
+++ b/Source/Misra/Std/Container/Vec.c
@@ -195,6 +195,9 @@ bool insert_range_into_vec(GenericVec *vec, const char *item_data, size item_siz
     }
 
     aligned_size = vec_aligned_size(vec, item_size);
+    if (count != 0 && aligned_size > SIZE_MAX / count) {
+        return false;
+    }
     if (vec->length + count >= vec->capacity) {
         if (!reserve_pow2_vec(vec, item_size, vec->capacity + count)) {
             return false;
@@ -257,6 +260,9 @@ bool insert_range_fast_into_vec(GenericVec *vec, const char *item_data, size ite
     }
 
     aligned_size = vec_aligned_size(vec, item_size);
+    if (count != 0 && aligned_size > SIZE_MAX / count) {
+        return false;
+    }
     if (vec->length + count >= vec->capacity) {
         if (!reserve_pow2_vec(vec, item_size, vec->length + count)) {
             return false;
@@ -323,6 +329,9 @@ void remove_range_vec(GenericVec *vec, void *removed_data, size item_size, size 
         }
     }
 
+    if ((vec->length - start - count) != 0 && vec_aligned_size(vec, item_size) > SIZE_MAX / (vec->length - start - count)) {
+        LOG_FATAL("integer overflow in remove_range_vec: aligned_size * move_count would overflow");
+    }
     // all elements to new created space
     MemMove(
         // move to freed up space
@@ -374,6 +383,9 @@ void fast_remove_range_vec(GenericVec *vec, void *removed_data, size item_size, 
     }
 
     if (elements_to_move > 0) {
+        if (vec_aligned_size(vec, item_size) > SIZE_MAX / elements_to_move) {
+            LOG_FATAL("integer overflow in fast_remove_range_vec: aligned_size * elements_to_move would overflow");
+        }
         // Move the last 'elements_to_move' elements to the gap
         MemMove(
             // Move to freed up space


### PR DESCRIPTION
## Summary
This PR adds overflow checks before computing byte counts for vector memory operations.

Several vector insert/remove paths compute sizes, such as:

- `aligned_size * count`
- `count * vec_aligned_size(vec)`
- `(vec->length - start - count) * vec_aligned_size(vec)`

These values are then passed to `MemMove` / `MemSet`. If the multiplication overflows `size`, the resulting byte count may no longer match the intended logical element count.

This change adds explicit guards before those multiplications, so the operation fails early rather than proceeding with a wrapped size value.

This is intended as defensive robustness / integer-overflow hardening. It is not claiming a demonstrated exploitable vulnerability without a concrete reproducer.


## Changes
- `Source/Misra/Std/Container/Vec.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
